### PR TITLE
Adjust token sizing, spacing, and label styling in TownSquare

### DIFF
--- a/src/components/TownSquare.tsx
+++ b/src/components/TownSquare.tsx
@@ -39,7 +39,7 @@ export function TownSquare({ players }: { players: Player[] }) {
         return () => ro.disconnect();
     }, []);
 
-    const N = clamp(players.length, 5, 20);
+    const N = clamp(players.length, 5, 18);
 
     // If not measured yet, render an empty container (avoids NaNs)
     if (layout.w === 0 || layout.h === 0) {
@@ -62,10 +62,18 @@ export function TownSquare({ players }: { players: Player[] }) {
     const centerY = topMargin + radius;
 
     // Token size: scales with available space
-    const tokenSize = clamp(Math.min(layout.w, layout.h) * 0.085, 48, 92);
+    const tokenSize = clamp(Math.min(layout.w, layout.h) * 0.095, 54, 104);
 
-    // Place tokens on the rim; adjust slightly outward if you prefer
-    const ringR = radius;
+    const spacingFactor = (() => {
+        if (N >= 18) return 1;
+        if (N <= 15) return 1.06;
+        const t = (18 - N) / 3;
+        return 1 + 0.06 * t;
+    })();
+
+    // Place tokens on the rim; adjust to control spacing between tokens
+    const minRingR = (tokenSize * spacingFactor) / (2 * Math.sin(Math.PI / N));
+    const ringR = Math.min(radius, minRingR);
 
     return (
         <div
@@ -141,7 +149,7 @@ export function TownSquare({ players }: { players: Player[] }) {
                                 >
                                     <path
                                         id={labelId}
-                                        d='M 18 74 Q 50 82 82 74'
+                                        d='M 14 80 Q 50 92 86 80'
                                         fill='none'
                                     />
                                     <text className={`token-label-svg ${p.name.length > 10 ? 'long' : ''}`}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -57,27 +57,27 @@ body {
 
 .token-label-svg {
   font-family: "Woodgod", serif;
-  font-weight: 700;
+  font-weight: 800;
 
   /* tweak for taste; SVG units */
-  font-size: 9.5px;
+  font-size: 11.2px;
 
-  letter-spacing: 0.18em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 
-  fill: rgba(0, 0, 0, 0.85);
+  fill: rgba(0, 0, 0, 0.98);
 
   /* “printed ink” readability */
   paint-order: stroke fill;
-  stroke: rgba(255, 255, 255, 0.65);
-  stroke-width: 0.6px;
+  stroke: rgba(255, 255, 255, 0.7);
+  stroke-width: 1px;
 
   dominant-baseline: middle;
 }
 
 .token-label-svg.long {
-  font-size: 8.8px;
-  letter-spacing: 0.16em;
+  font-size: 10px;
+  letter-spacing: 0.14em;
 }
 
 


### PR DESCRIPTION
### Motivation
- Improve readability of main token labels by making them bolder, larger and darker.
- Lower the SVG label baseline so the decorative token text sits closer to the bottom of the token.
- Make tokens slightly larger overall to improve visibility.
- Keep token layout compact at 15 players but allow a continuous chain up to a capped maximum of 18 tokens.

### Description
- Cap displayed tokens to 18 by changing the clamp in `TownSquare` from `20` to `18` and increase the base token size via `tokenSize` calculation.
- Add a `spacingFactor` and compute `minRingR` to adjust the ring radius so spacing is slightly increased for 15-player layouts but stays tight up to 18 players in `src/components/TownSquare.tsx`.
- Lower the label path by changing the SVG path coordinates (from `M 18 74 Q 50 82 82 74` to `M 14 80 Q 50 92 86 80`) so labels sit nearer the bottom of tokens.
- Strengthen label styling in `src/styles.css` by increasing `font-weight`, `font-size`, darkening `fill`, and increasing `stroke-width`, and adjust the `.long` variant font size/letter-spacing.

### Testing
- Started the local dev server with `yarn dev`, which successfully served the app (Vite ready).
- Captured a screenshot with a Playwright script, which ran successfully and produced `artifacts/town-square.png`.
- No unit tests or CI test suite were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b454736c832a9fca4c04abb46e9b)