### PR TITLE
Restore town circle size, move token labels down, and increase label emphasis

### DIFF
--- a/src/components/TownSquare.tsx
+++ b/src/components/TownSquare.tsx
@@ -54,7 +54,7 @@ export function TownSquare({ players }: { players: Player[] }) {
     // Circle sizing:
     // - "halfway to vertical edges from center" => width/4
     // - cap by height so it doesn't run off-screen
-    const radius = Math.min(layout.w / 3, layout.h * 0.42);
+    const radius = Math.min(layout.w * 0.45, layout.h * 0.45);
 
     // "top edge about 1/12 down from top"
     const topMargin = layout.h / 12;
@@ -150,7 +150,7 @@ export function TownSquare({ players }: { players: Player[] }) {
                                 >
                                     <path
                                         id={labelId}
-                                        d='M 18 74 Q 50 82 82 74'
+                                        d='M 14 86 Q 50 96 86 86'
                                         fill='none'
                                     />
                                     <text className={`token-label-svg ${p.name.length > 10 ? 'long' : ''}`}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,9 +17,9 @@ body {
 
 .token-label-svg {
   font-family: "Open Sans", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-  font-weight: 700;
+  font-weight: 800;
 
-  font-size: 15px;
+  font-size: 19px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 
@@ -34,7 +34,7 @@ body {
 }
 
 .token-label-svg.long {
-  font-size: 13.5px;
+  font-size: 16.5px;
   letter-spacing: 0.05em;
 }
 


### PR DESCRIPTION
### Motivation
- Revert the unintended shrink of the town circle and restore a larger placement for tokens on the rim. 
- Make token name labels larger and bolder for improved readability on textured token artwork. 
- Move the arc used for name labels further down so text sits closer to the bottom of the token (near the parent token edge). 
- Preserve existing token sizing/spacing behavior while improving label placement and emphasis.

### Description
- Update circle sizing to use `const radius = Math.min(layout.w * 0.45, layout.h * 0.45)` to restore a larger town circle. 
- Move label arc downward by changing the SVG path `d` value to `M 14 86 Q 50 96 86 86` so labels sit lower along the rim. 
- Increase label font weight to `800` and font sizes from `15px` to `19px` (and long variant from `13.5px` to `16.5px`) in `.token-label-svg` for stronger emphasis. 
- No other layout or token-spacing logic was changed; token size and ring radius calculation remain intact.

### Testing
- Started the dev server with `yarn dev` and the Vite server came up successfully (visual verification possible). 
- Captured a screenshot via a Playwright script which produced `artifacts/town-square.png` to verify the visual changes (succeeded). 
- No unit or snapshot tests were modified or executed for these visual-only changes. 
- Visual verification performed using the generated screenshot artifact (manual/automated screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c13b49b8832a8eab02a57eccaf95)