### PR TITLE
Fix ESLint tsconfigRootDir resolution

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,6 @@
 //eslint.config.ts
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import js from '@eslint/js';
 import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
@@ -6,6 +8,8 @@ import prettierPlugin from 'eslint-plugin-prettier';
 import globals from 'globals'; // Use the 'globals' package if available, or define manually
 import reactPlugin from 'eslint-plugin-react';
 import hooksPlugin from 'eslint-plugin-react-hooks';
+
+const tsconfigRootDir = path.dirname(fileURLToPath(import.meta.url));
 
 export default [
     js.configs.recommended,
@@ -26,7 +30,7 @@ export default [
             parser: tsParser,
             parserOptions: {
                 project: './tsconfig.json',
-                tsconfigRootDir: import.meta.dirname
+                tsconfigRootDir
             },
             globals: {
                 ...globals.node, // This fixes 'Buffer' and 'process'


### PR DESCRIPTION
### Motivation
- ESLint produced a parsing error because the typescript-eslint parser could not reliably resolve the `tsconfig.json` root when using `import.meta` in an ESM config.
- The intent is to ensure `parserOptions.project` points to the correct TSConfig directory so typed linting includes all project files.

### Description
- Compute `tsconfigRootDir` using `path.dirname(fileURLToPath(import.meta.url))` and supply it to `parserOptions` in `eslint.config.ts`.
- Add imports for `node:path` and `fileURLToPath` from `node:url` and replace `import.meta.dirname` with the computed `tsconfigRootDir`.
- Update is limited to `eslint.config.ts` and does not alter any other ESLint rules or project files.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a212559ec832abf5eda4c4f5e6f57)