### PR TITLE
Add world-building worksheet data model to seated players

### DIFF
--- a/src/store/game/game-slice.ts
+++ b/src/store/game/game-slice.ts
@@ -72,6 +72,54 @@ export interface ISeatedPlayer {
     reminders: string;
     isDrunk: boolean;
     isPoisoned: boolean;
+    worldBuildingWorksheet?: WorldBuildingWorksheet;
+}
+
+export type PlayerId = ISeatedPlayer['ID'];
+
+export interface WorldBuildingWorksheet {
+    demon: DemonWorldModel;
+    minions: MinionWorldModel;
+    outsiders: OutsiderWorldModel;
+    setupModifiers: SetupModifierWorldModel;
+    intoxication: IntoxicationWorldModel;
+    notes?: string;
+}
+
+export interface DemonWorldModel {
+    role?: Roles;
+    specialAbilities?: string[];
+    killsPerNight?: number;
+    constraints?: string[];
+    notes?: string;
+}
+
+export interface MinionWorldModel {
+    expectedCount?: number;
+    confirmed?: Roles[];
+    possibleSets?: Roles[][];
+    notes?: string;
+}
+
+export interface OutsiderWorldModel {
+    baseCount?: number;
+    currentCount?: number;
+    suspectedModifiers?: string[];
+    notes?: string;
+}
+
+export interface SetupModifierWorldModel {
+    suspectedModifiers?: string[];
+    confirmedModifiers?: string[];
+    notes?: string;
+}
+
+export interface IntoxicationWorldModel {
+    knownDrunk?: PlayerId[];
+    knownPoisoned?: PlayerId[];
+    suspectedDrunk?: PlayerId[];
+    suspectedPoisoned?: PlayerId[];
+    notes?: string;
 }
 
 export type TrustModels = 'all_trusting' | 'skeptical' | 'doubting_thomas';


### PR DESCRIPTION
### Motivation
- Provide each seated player with a structured per-player workspace to capture hypotheses about the game world such as demon identity, minions, outsiders, setup modifiers, and intoxication state.
- Support downstream AI or human reasoning by centralizing common world-building signals that influence inference and decision-making during play.
- Make it easier to represent and update candidate sets (e.g. possible minion combinations) and track known vs suspected intoxication effects on information.

### Description
- Added an optional `worldBuildingWorksheet` property to `ISeatedPlayer` in `src/store/game/game-slice.ts`.
- Introduced a `PlayerId` alias and a `WorldBuildingWorksheet` root interface that aggregates specialist submodels.
- Implemented sub-interfaces: `DemonWorldModel`, `MinionWorldModel`, `OutsiderWorldModel`, `SetupModifierWorldModel`, and `IntoxicationWorldModel` to capture relevant fields and notes.
- All new types are defined alongside the existing game slice types to be available for state and future UI or AI logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a50371f68832a90588fd05095ccec)