### PR TITLE
Add TopBar scripts dropdown, BottomBar chat/population headers, and new sidebar entries

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -9,7 +9,15 @@ import {
     useSidebar
 } from '@/components/ui/sidebar';
 import { Link } from '@tanstack/react-router';
-import { Home, Users, Settings } from 'lucide-react';
+import {
+    BookOpen,
+    Clock,
+    ClipboardList,
+    History,
+    Home,
+    Settings,
+    Users
+} from 'lucide-react';
 
 function SidebarBrandToggle() {
     const { toggleSidebar } = useSidebar();
@@ -74,6 +82,54 @@ export function AppSidebar() {
                             <Link to='/'>
                                 <Settings className='h-4 w-4' />
                                 <span>Settings</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    <SidebarMenuItem>
+                        <SidebarMenuButton
+                            asChild
+                            tooltip='ST Consult'
+                        >
+                            <Link to='/'>
+                                <BookOpen className='h-4 w-4' />
+                                <span>ST Consult</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    <SidebarMenuItem>
+                        <SidebarMenuButton
+                            asChild
+                            tooltip='Timer'
+                        >
+                            <Link to='/'>
+                                <Clock className='h-4 w-4' />
+                                <span>Timer</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    <SidebarMenuItem>
+                        <SidebarMenuButton
+                            asChild
+                            tooltip='Task Queue'
+                        >
+                            <Link to='/'>
+                                <ClipboardList className='h-4 w-4' />
+                                <span>Task Queue</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    <SidebarMenuItem>
+                        <SidebarMenuButton
+                            asChild
+                            tooltip='Voting History'
+                        >
+                            <Link to='/'>
+                                <History className='h-4 w-4' />
+                                <span>Voting History</span>
                             </Link>
                         </SidebarMenuButton>
                     </SidebarMenuItem>

--- a/src/components/BottomBar.tsx
+++ b/src/components/BottomBar.tsx
@@ -3,7 +3,10 @@ export function BottomBar({ className }: { className: string }) {
     const $cn = [className, 'border-t bg-background'].join(' ');
     return (
         <nav className={$cn}>
-            <div className='mx-auto flex h-14 max-w-screen-sm items-center justify-around px-2'>{/* buttons */}</div>
+            <div className='mx-auto flex h-14 max-w-screen-sm items-center justify-between gap-4 px-4 text-sm font-semibold'>
+                <div className='flex flex-1 items-center justify-start'>Chat</div>
+                <div className='flex flex-1 items-center justify-end'>Population</div>
+            </div>
         </nav>
     );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,8 +1,23 @@
 // src/components/TopBar.tsx
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuShortcut,
+    DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu';
 import { Menu } from 'lucide-react';
 import { SidebarTrigger } from './ui/sidebar';
+import editions from '@/data/editions.json';
+
+const popularScriptIds = ['tb', 'snv'];
+const popularScripts = editions.filter((script) => popularScriptIds.includes(script.id));
+const officialScripts = editions.filter((script) => script.isOfficial);
 
 function SidebarNav() {
     return (
@@ -25,13 +40,25 @@ function SidebarNav() {
             >
                 Settings
             </a>
+            <a
+                className='block rounded-md px-3 py-2 hover:bg-accent'
+                href='/setup'
+            >
+                Setup
+            </a>
+            <a
+                className='block rounded-md px-3 py-2 hover:bg-accent'
+                href='/scripts'
+            >
+                Scripts
+            </a>
         </nav>
     );
 }
 
 export function TopBar() {
     return (
-        <header className='sticky top-0 z-40 flex h-14 items-center border-b bg-background px-3'>
+        <header className='sticky top-0 z-40 flex h-14 items-center gap-3 border-b bg-background px-3'>
             <div className='hidden md:flex'>
                 <SidebarTrigger />
             </div>
@@ -57,7 +84,55 @@ export function TopBar() {
                 </Sheet>
             </div>
 
-            <div className='ml-2 text-sm font-semibold'>Game</div>
+            <div className='flex items-center gap-2 text-sm font-semibold'>
+                <span>Game</span>
+                <span className='text-muted-foreground'>/</span>
+                <span>Setup</span>
+            </div>
+
+            <div className='ml-auto flex items-center gap-2'>
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            variant='ghost'
+                            className='h-9 px-3'
+                        >
+                            Scripts
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                        align='end'
+                        className='w-56'
+                    >
+                        <DropdownMenuLabel>Popular scripts</DropdownMenuLabel>
+                        <DropdownMenuGroup>
+                            {popularScripts.map((script) => (
+                                <DropdownMenuItem key={script.id}>
+                                    {script.name}
+                                    <DropdownMenuShortcut>Load to setup</DropdownMenuShortcut>
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuGroup>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuLabel>Official scripts</DropdownMenuLabel>
+                        <DropdownMenuGroup>
+                            {officialScripts.map((script) => (
+                                <DropdownMenuItem key={script.id}>
+                                    {script.name}
+                                    <DropdownMenuShortcut>Load to setup</DropdownMenuShortcut>
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuGroup>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+
+                <Button
+                    variant='ghost'
+                    className='h-9 px-3'
+                >
+                    Settings (Preferences)
+                </Button>
+            </div>
         </header>
     );
 }


### PR DESCRIPTION
### Motivation
- Provide quick access to popular and official scripts from the top bar and make Setup and Settings more discoverable. 
- Surface chat and population information in the bottom bar for clearer app sections. 
- Extend the sidebar with commonly requested utilities: ST Consult, Timer, Task Queue, and Voting History. 
- Keep UI consistent and drive users toward loading scripts into Setup from a single menu. 

### Description
- Updated `src/components/TopBar.tsx` to add a `Scripts` dropdown using the existing `DropdownMenu` primitives and to show `Game / Setup` breadcrumbs. 
- The top bar now reads `editions.json` and builds `popularScripts` and `officialScripts` lists to populate the dropdown menu items. 
- Updated `src/components/BottomBar.tsx` to add `Chat` and `Population` headers in the bottom navigation area. 
- Updated `src/components/AppSidebar.tsx` to add entries (and icons) for `ST Consult`, `Timer`, `Task Queue`, and `Voting History`. 

### Testing
- Attempted to run the dev server with `npm run dev`, which started Vite but encountered a server-side runtime error (`ReferenceError: window is not defined`) originating in `TownSquare.tsx`. 
- Captured a UI screenshot by running a Playwright script which successfully produced `artifacts/topbar-bottom-bar.png`. 
- Changes were lint/compile checked during local dev startup but the SSR runtime error prevented a full dev session. 
- No unit tests were executed as part of this change set (UI-only updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a845fb874832a97c2c600dbbb7204)