### PR TITLE
Add dedicated tsconfig for ESLint typed linting

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -29,7 +29,7 @@ export default [
         languageOptions: {
             parser: tsParser,
             parserOptions: {
-                project: './tsconfig.json',
+                project: './tsconfig.eslint.json',
                 tsconfigRootDir
             },
             globals: {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["**/*.ts", "**/*.tsx", "eslint.config.ts", "vite.config.ts"]
+}


### PR DESCRIPTION
### Motivation
- ESLint reported a parsing error because `parserOptions.project` referenced `tsconfig.json` which did not include certain linted files like `eslint.config.ts`.
- Using the primary `tsconfig.json` for typed linting can omit non-source or config files, causing false positive lint failures.
- A dedicated tsconfig for ESLint ensures all files linted by ESLint are included without changing project-wide compile settings.

### Description
- Updated `eslint.config.ts` to point `parserOptions.project` to `./tsconfig.eslint.json`.
- Added `tsconfig.eslint.json` which `extends` `./tsconfig.json` and `include`s `**/*.ts`, `**/*.tsx`, `eslint.config.ts`, and `vite.config.ts`.
- This change makes typed linting aware of the ESLint config and other files so parsing errors are resolved.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3ede1ef4832a98a59793172d7a14)