### PR TITLE
Add `DailyDemocracyManager` type to game slice

### DIFF
--- a/src/store/game/game-slice.ts
+++ b/src/store/game/game-slice.ts
@@ -77,6 +77,11 @@ export interface ISeatedPlayer {
 
 export type PlayerId = ISeatedPlayer['ID'];
 
+export interface DailyDemocracyManager {
+    nomineePool: PlayerId[];
+    nominatorPool: PlayerId[];
+}
+
 export interface WorldBuildingWorksheet {
     demon: DemonWorldModel;
     minions: MinionWorldModel;


### PR DESCRIPTION
### Motivation
- Introduce a typed manager to track daily nomination state for the democracy flow in the game model.
- Capture two distinct pools: who is allowed to nominate and who may be nominated for a given day.

### Description
- Added a `DailyDemocracyManager` interface to `src/store/game/game-slice.ts` with `nomineePool` and `nominatorPool` fields. 
- Both pools are typed as arrays of `PlayerId` and integrate with existing game slice types. 
- Placement is adjacent to `PlayerId` so it is available to other game-related types and logic. 

### Testing
- No automated tests were executed for this change. 
- The change is a purely type-level addition and does not modify runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9a9179b0832a943e6f99fde7515b)