### PR TITLE
Make History panel draggable, add bottom color key, and drain storyteller queue in AI orchestrator

### DIFF
--- a/src/components/BottomBar.tsx
+++ b/src/components/BottomBar.tsx
@@ -3,9 +3,33 @@ export function BottomBar({ className }: { className: string }) {
     const $cn = [className, 'border-t bg-background'].join(' ');
     return (
         <nav className={$cn}>
-            <div className='mx-auto flex h-14 max-w-screen-sm items-center justify-between gap-4 px-4 text-sm font-semibold'>
+            <div className='mx-auto flex min-h-14 max-w-screen-sm items-center justify-between gap-4 px-4 py-3 text-sm font-semibold'>
                 <div className='flex flex-1 items-center justify-start'>Chat</div>
                 <div className='flex flex-1 items-center justify-end'>Population</div>
+            </div>
+            <div className='border-t border-border/60 bg-background/95'>
+                <div className='mx-auto flex max-w-screen-sm flex-wrap items-center justify-center gap-3 px-4 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground'>
+                    <span className='flex items-center gap-1.5'>
+                        <span className='h-2 w-2 rounded-full bg-red-500' />
+                        Demon / Evil
+                    </span>
+                    <span className='flex items-center gap-1.5'>
+                        <span className='h-2 w-2 rounded-full bg-blue-500' />
+                        Townsfolk / Blue
+                    </span>
+                    <span className='flex items-center gap-1.5'>
+                        <span className='h-2 w-2 rounded-full bg-orange-500' />
+                        Minions
+                    </span>
+                    <span className='flex items-center gap-1.5'>
+                        <span className='h-2 w-2 rounded-full bg-cyan-400' />
+                        Outsiders
+                    </span>
+                    <span className='flex items-center gap-1.5'>
+                        <span className='h-2 w-2 rounded-full bg-yellow-400' />
+                        Travelers + Misregisters (Recluse, Spy)
+                    </span>
+                </div>
             </div>
         </nav>
     );


### PR DESCRIPTION
### Motivation
- Allow the History UI to be repositioned by the user and keep resizing available for better UX during sessions.  
- Provide a persistent color legend near the bottom UI so team/role colors are always visible.  
- Allow the night-run AI flow to start from the Storyteller queue when the AI orchestrator queue is empty so queued storyteller tasks are processed.  

### Description
- Implemented a draggable, positionable `HistoryPanel` by adding refs, pointer-handling, initial position calculation, and clamped viewport placement in `src/components/HistoryPanel.tsx`.  
- Kept panel resize behavior and preserved collapse/expand behavior while switching to absolute positioning when moved.  
- Added a color key legend under the bottom bar in `src/components/BottomBar.tsx` showing red/blue/orange/cyan/yellow mappings.  
- Updated `orchestrateNext` in `src/store/ai-orchestrator/ai-orchestrator-slice.ts` to pull from `storytellerQueue` when the AI queue is empty and to dequeue/clear the storyteller current item when consumed.  

### Testing
- Started the dev server with `npm run dev` which served the app but the runtime surfaced `ReferenceError: createDynamicMiddlewareRegistry is not defined`.  
- Captured a UI screenshot using Playwright which completed and produced `artifacts/botc-ui.png`.  
- No unit or integration test suites were executed as part of this change.  
- The UI and flow changes were compiled and verified to render in the dev build up until the runtime middleware error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa1d41aa8832a9dc7b7fe4c970b12)