### PR TITLE
Add storyteller queue task type definitions

### DIFF
--- a/src/store/st-queue-types.ts
+++ b/src/store/st-queue-types.ts
@@ -1,0 +1,33 @@
+// src/store/st-queue-types.ts
+export type STStepType =
+    | 'wake_choice' // wake player, they choose target(s)
+    | 'wake_info' // wake player, give info only
+    | 'check_trigger' // deterministic check (no wake)
+    | 'prepare_info' // compute candidate info but DO NOT commit to grimoire
+    | 'commit_info' // commit prepared info to grimoire + reminders
+    | 'resolve_effect'; // resolve ongoing effects, reminders, flips, etc.
+
+export type STInteraction =
+    | 'ai' // auto-prompt AI + parse response
+    | 'human' // pause and wait for UI response
+    | 'none'; // no interaction needed
+
+export type STTask = {
+    id: string;
+    kind: 'night_step' | 'log' | 'custom';
+    phase: 'night' | 'day' | 'setup' | 'dawn';
+
+    roleId?: string; // e.g. "poisoner", "washerwoman"
+    stepType: STStepType;
+
+    /** which seat(s) this step applies to (some roles have multiple instances) */
+    seatIds?: number[];
+
+    interaction: STInteraction;
+
+    /** used for ordering + sanity checks */
+    nightNumber: number;
+
+    /** scratch / prepared results stored somewhere (not in task if big) */
+    payload?: Record<string, any>;
+};


### PR DESCRIPTION
### Motivation
- Centralize and formalize types used by the storyteller/night queue to make them reusable across the store and orchestrator.
- Provide a clear shape for night-step tasks and interactions to reduce ad-hoc object shapes and improve type-safety.
- Prepare for subsequent code that will consume these types (queue processing, AI orchestration, UI interactions).

### Description
- Add a new module `src/store/st-queue-types.ts` containing type definitions.
- Introduce `STStepType` union for night-step kinds like `wake_choice`, `prepare_info`, and `resolve_effect`.
- Introduce `STInteraction` union with `ai`, `human`, and `none` options.
- Add `STTask` type describing task fields such as `id`, `kind`, `phase`, `stepType`, `interaction`, `nightNumber`, and `payload`.

### Testing
- No automated tests were executed for this change.
- This change is type-only and does not alter runtime behavior, so CI type-checking is expected to validate integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa682a4cc832a9856395ee7a2ae25)