### PR TITLE
Fix storyteller queue state shape and actions

### DIFF
--- a/src/store/ai-orchestrator/ai-orchestrator-slice.ts
+++ b/src/store/ai-orchestrator/ai-orchestrator-slice.ts
@@ -1,7 +1,7 @@
 // src/store/ai-orchestrator/ai-orchestrator-slice.ts
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { addLogEntry } from '../history/history-slice';
-import { IStorytellerQueueItem, storytellerQueueSlice } from '../st-queue/st-queue-slice';
+import { IStorytellerQueueItem, StorytellerQueueState, storytellerQueueSlice } from '../st-queue/st-queue-slice';
 
 export type AiOrchestratorStatus = 'idle' | 'pending' | 'fulfilled' | 'errored';
 export type AiHttpFunctionTarget = 'storyteller' | 'player' | 'system';
@@ -88,7 +88,7 @@ export const initialState: IAiOrchestratorState = {
 export const orchestrateNext = createAsyncThunk<
     IAiOrchestratorResult,
     void,
-    { state: { aiOrchestrator: IAiOrchestratorState; storytellerQueue: { items: IStorytellerQueueItem[]; currentItem: IStorytellerQueueItem | null } } }
+    { state: { aiOrchestrator: IAiOrchestratorState; storytellerQueue: StorytellerQueueState } }
 >('aiOrchestrator/orchestrateNext', async (_, { dispatch, getState, rejectWithValue }) => {
     const rootState = getState();
     const state = rootState.aiOrchestrator;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -46,14 +46,14 @@ listenerMiddleware.startListening({
 });
 
 listenerMiddleware.startListening({
-    actionCreator: storytellerQueueSlice.actions.enqueueTask,
+    actionCreator: storytellerQueueSlice.actions.enqueueBack,
     effect: (action, listenerApi) => {
         listenerApi.dispatch(enqueueBack(mapStorytellerQueueItem(action.payload)));
     }
 });
 
 listenerMiddleware.startListening({
-    actionCreator: storytellerQueueSlice.actions.pushtask,
+    actionCreator: storytellerQueueSlice.actions.enqueueFront,
     effect: (action, listenerApi) => {
         listenerApi.dispatch(enqueueFront(mapStorytellerQueueItem(action.payload)));
     }


### PR DESCRIPTION
### Motivation
- Establish a single consistent state shape for the storyteller queue to avoid duplicated/ambiguous fields and selectors.
- Ensure thunks operate against a coherent API so task processing (`runNextTask`, `runTasks`) handles `currentItem` and queued `items` correctly.
- Remove duplicate reducer declarations and stray/exported actions that didn't match the slice shape.
- Update cross-feature references so listener middleware and the AI orchestrator integrate with the new queue API.

### Description
- Reworked `StorytellerQueueState` to use `items: IStorytellerQueueItem[]`, `currentItem: IStorytellerQueueItem | null`, `awaitingHumanTaskId: string | null`, and `lastRunAtMs: number | null` and adjusted `initialState` accordingly.
- Added `StorytellerInteraction`, `StorytellerTaskHandler`, and `StorytellerQueueThunkExtra` types and updated thunks to use `extra.stHandlers` and the new state shape, including `runNextTask` and `runTasks` logic to respect `currentItem` and `items`.
- Replaced duplicate/misnamed reducers with a coherent set: `enqueueBack`, `enqueueFront`, `dequeueNext`, `clearQueue`, `clearCurrent`, `setRunning`, `setError`, `setAwaitingHumanTaskId`, and `setLastRunAtMs`, and exported matching selectors.
- Updated cross-feature code to match new action/selectors: listener middleware in `src/store/index.ts` now listens for `enqueueBack`/`enqueueFront`, and `ai-orchestrator` thunk typing now references `StorytellerQueueState` and uses `dequeueNext`/`clearCurrent` correctly.

### Testing
- No automated tests were executed as part of this change.
- Type-check/build was not run in this rollout.
- Manual smoke validation was not performed (no runtime test run requested).
- Files modified: `src/store/st-queue/st-queue-slice.ts`, `src/store/index.ts`, and `src/store/ai-orchestrator/ai-orchestrator-slice.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0e4be4d8832ab38275ad72b1763e)