### PR TITLE
Import dynamic middleware registry and add middleware barrel

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import { chatsSlice } from './chats/chats-slice';
 import { gameSlice } from './game/game-slice';
 import { grimoireSlice } from './grimoire/grimoire-slice';
 import { addLogEntry, historySlice } from './history/history-slice';
+import { createDynamicMiddlewareRegistry } from './middleware/dynamic-middleware';
 import { IStorytellerQueueItem, storytellerQueueSlice } from './st-queue/st-queue-slice';
 import { votingSlice } from './voting/voting-slice';
 

--- a/src/store/middleware/index.ts
+++ b/src/store/middleware/index.ts
@@ -1,0 +1,2 @@
+// src/store/middleware/index.ts
+export { createDynamicMiddlewareRegistry } from './dynamic-middleware';


### PR DESCRIPTION
### Motivation
- Ensure `createDynamicMiddlewareRegistry` is imported where the registry is instantiated.
- Keep `src/store/index.ts` tidy by centralizing middleware exports for future additions.
- Preserve the existing `dynamicMiddlewareRegistry` usage and middleware chain in the store configuration.

### Description
- Added `import { createDynamicMiddlewareRegistry } from './middleware/dynamic-middleware';` to `src/store/index.ts`.
- Added a new barrel file `src/store/middleware/index.ts` that re-exports `createDynamicMiddlewareRegistry`.
- Left the existing `dynamicMiddlewareRegistry` instantiation and its inclusion in the middleware chain unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0e4d7e10832aa0d1a6d99dc724f5)