### PR TITLE
feat(ui): add overlay dialog components

### DIFF
--- a/src/components/overlays/DawnBreaksDialog.tsx
+++ b/src/components/overlays/DawnBreaksDialog.tsx
@@ -1,0 +1,25 @@
+import dawnBreaksImg from '@/assets/images/dawn-breaks.jpeg';
+
+import { GameOverlay } from './GameOverlay';
+
+type OverlayDialogProps = {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+};
+
+export function DawnBreaksDialog({ open, onOpenChange }: OverlayDialogProps) {
+    return (
+        <GameOverlay
+            open={open}
+            onOpenChange={onOpenChange}
+            title='Dawn Breaks'
+            description='Wake up. The day phase begins.'
+            imageSrc={dawnBreaksImg}
+            imageAlt='Sunrise'
+        >
+            <p className='text-center text-base text-slate-100'>
+                Please open your eyes and discuss the night’s events.
+            </p>
+        </GameOverlay>
+    );
+}

--- a/src/components/overlays/GameOverlay.tsx
+++ b/src/components/overlays/GameOverlay.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+type GameOverlayProps = {
+    open: boolean;
+    title: string;
+    description?: string;
+    imageSrc?: string;
+    imageAlt?: string;
+    className?: string;
+    contentClassName?: string;
+    onOpenChange?: (open: boolean) => void;
+    children?: React.ReactNode;
+};
+
+export function GameOverlay({
+    open,
+    title,
+    description,
+    imageSrc,
+    imageAlt,
+    className,
+    contentClassName,
+    onOpenChange,
+    children
+}: GameOverlayProps) {
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={onOpenChange}
+        >
+            <DialogContent
+                showCloseButton={false}
+                className={cn('border-none bg-slate-950/90 p-0 text-white shadow-2xl sm:max-w-[680px]', className)}
+            >
+                <div className='relative overflow-hidden rounded-lg'>
+                    {imageSrc ?
+                        <img
+                            src={imageSrc}
+                            alt={imageAlt ?? title}
+                            className='absolute inset-0 h-full w-full object-cover opacity-60'
+                            draggable={false}
+                        />
+                    :   null}
+                    <div className='absolute inset-0 bg-gradient-to-b from-slate-950/70 via-slate-950/80 to-slate-950' />
+                    <div className={cn('relative z-10 flex flex-col gap-6 px-8 py-10', contentClassName)}>
+                        <DialogHeader className='text-center'>
+                            <DialogTitle className='text-3xl font-black uppercase tracking-wide text-white drop-shadow'>
+                                {title}
+                            </DialogTitle>
+                            {description ?
+                                <DialogDescription className='text-base text-slate-200'>
+                                    {description}
+                                </DialogDescription>
+                            :   null}
+                        </DialogHeader>
+                        {children}
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/overlays/NightFallsDialog.tsx
+++ b/src/components/overlays/NightFallsDialog.tsx
@@ -1,0 +1,25 @@
+import nightFallsImg from '@/assets/images/night-falls.jpg';
+
+import { GameOverlay } from './GameOverlay';
+
+type OverlayDialogProps = {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+};
+
+export function NightFallsDialog({ open, onOpenChange }: OverlayDialogProps) {
+    return (
+        <GameOverlay
+            open={open}
+            onOpenChange={onOpenChange}
+            title='Night Falls'
+            description='Close your eyes. The night phase has begun.'
+            imageSrc={nightFallsImg}
+            imageAlt='Night sky'
+        >
+            <p className='text-center text-base text-slate-200'>
+                Minions and demons, keep your heads down until called.
+            </p>
+        </GameOverlay>
+    );
+}

--- a/src/components/overlays/TimesUpDialog.tsx
+++ b/src/components/overlays/TimesUpDialog.tsx
@@ -1,0 +1,23 @@
+import clockImg from '@/assets/images/town/clock-big.png';
+
+import { GameOverlay } from './GameOverlay';
+
+type OverlayDialogProps = {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+};
+
+export function TimesUpDialog({ open, onOpenChange }: OverlayDialogProps) {
+    return (
+        <GameOverlay
+            open={open}
+            onOpenChange={onOpenChange}
+            title="Time's Up"
+            description='The allotted time has ended.'
+            imageSrc={clockImg}
+            imageAlt='Clock face'
+        >
+            <p className='text-center text-lg font-semibold text-amber-100'>Please return to the town square.</p>
+        </GameOverlay>
+    );
+}


### PR DESCRIPTION
### Motivation
- Introduce a reusable dialog wrapper for game-related overlays to centralize styling and behavior.
- Provide themed, image-backed overlays for common game phases (Times Up, Night Falls, Dawn Breaks) to improve UX.
- Keep overlay markup consistent and easily composable for future phase or event dialogs.

### Description
- Add `GameOverlay` component in `src/components/overlays/GameOverlay.tsx` that wraps the app `Dialog` with image, gradient, header, and content slots.
- Add `TimesUpDialog`, `NightFallsDialog`, and `DawnBreaksDialog` in `src/components/overlays` that consume `GameOverlay` and reference themed images from `src/assets/images`.
- Create the `src/components/overlays` folder and add the four new files with Tailwind-based styling and accessible dialog structure.
- Run code formatting on the new overlay files with Prettier to normalize style.

### Testing
- `npm run format` was attempted but failed due to Prettier CLI usage requiring explicit file arguments.
- `npx prettier --write src/components/overlays/*.tsx` was run and completed successfully, formatting the new files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b15b85ae4832ab29bfda00f9ce12d)