### PR TITLE
feat(ui/town-square): add reminder tokens and copy overlay components

### DIFF
--- a/src/components/overlays/OverlayElement.tsx
+++ b/src/components/overlays/OverlayElement.tsx
@@ -1,0 +1,19 @@
+// src/components/overlays/OverlayElement.tsx
+
+export function OverlayElement({
+    stateSelector,
+    oppositeSelector,
+    pseudoSelector
+}: {
+    stateSelector: string;
+    oppositeSelector: string;
+    pseudoSelector: string;
+}) {
+    const cn = [
+        oppositeSelector,
+        pseudoSelector,
+        stateSelector,
+        'absolute inset-0 h-full w-full rounded-full z-10  border-0 ring-0 outline-0'
+    ].join(' ');
+    return <div className={cn} />;
+}

--- a/src/components/overlays/ShadedOverlay.tsx
+++ b/src/components/overlays/ShadedOverlay.tsx
@@ -1,0 +1,10 @@
+// src/components/overlays/ShadedOverlay.tsx
+import { OverlayElement } from './OverlayElement';
+
+// 'invisible data-[is-dead=true]:visible  bg-black/65 '
+export const ShadedOverlay = () =>
+    OverlayElement({
+        oppositeSelector: 'invisible',
+        pseudoSelector: 'group-data-[is-dead=true]:visible',
+        stateSelector: 'bg-black/65'
+    });


### PR DESCRIPTION
### Motivation
- Provide a lightweight, visual reminder/token system on the Town Square to annotate seats with status, custom notes and ghost-votes. 
- Reuse existing overlay building blocks by copying `OverlayElement`/`ShadedOverlay` into a shared `overlays` folder for consistent UI composition. 
- Surface small token UI for alive/dead state, flipped tokens, and simple add/remove flows so the town-square is more informative during play. 
- Add minimal model fields to the game slice so reminder tokens carry display metadata.

### Description
- Extended `src/components/TownSquare.tsx` to render per-seat reminder tokens, including `ReminderTokenBadge` and `ReminderAdder` components, role-based reminder option generation, flipped/token-base visuals, and UI for adding/removing tokens. 
- Integrated store usage via `useAppDispatch` and `useAppSelector` and wired `addReminderToken`/`removeReminderToken` actions and grimoire selectors to compute reminders, flipped state, and seat conditions. 
- Added fallback support so `TownSquare` uses Redux seats when `players` prop is not provided and adjusted token rendering (life/death base, ghost vote icon, scaled reminder sizing). 
- Copied overlay helpers into `src/components/overlays/OverlayElement.tsx` and `src/components/overlays/ShadedOverlay.tsx` and updated `src/store/game/game-slice.ts` to add `label?: string` and `typeKey?: string` to the reminder token type.

### Testing
- Attempted code formatting with `npm run format`, but Prettier invocation failed due to missing file/dir arguments and therefore did not complete. 
- No Jest unit tests were executed (`npm run test` was not run). 
- New overlay files were created and validated locally for compile (no runtime test harness executed). 
- Recommend running `npm run format` with appropriate targets and `npm run test` after integrating the grimoire reducer/actions into the app to catch any TypeScript or runtime issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b168a6a68832aad41f3babb1f0fed)