### PR TITLE
Add radial reminder token slots for player tokens

### DIFF
--- a/src/components/CharacterTokenParent.tsx
+++ b/src/components/CharacterTokenParent.tsx
@@ -27,6 +27,8 @@ export function CharacterTokenParent({
     isDrunk,
     isPoisoned,
     reminders,
+    reminderSlots,
+    reminderTokenSize,
     firstNightOrder,
     otherNightOrder
 }: {
@@ -45,6 +47,8 @@ export function CharacterTokenParent({
     isDrunk?: boolean;
     isPoisoned?: boolean;
     reminders?: string;
+    reminderSlots?: Array<{ x: number; y: number }>;
+    reminderTokenSize?: number;
     firstNightOrder?: number;
     otherNightOrder?: number;
 }) {
@@ -83,6 +87,22 @@ export function CharacterTokenParent({
                     data-is-marked={isMarked}
                 />
                 {children}
+                {reminderSlots && reminderTokenSize ?
+                    reminderSlots.map((slot, index) => (
+                        <span
+                            key={`reminder-slot-${index}`}
+                            className='absolute rounded-full border border-dashed border-muted-foreground/40 opacity-0'
+                            style={{
+                                width: reminderTokenSize,
+                                height: reminderTokenSize,
+                                left: slot.x - x,
+                                top: slot.y - y
+                            }}
+                            aria-hidden='true'
+                            data-reminder-slot
+                        />
+                    ))
+                :   null}
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <span className='place-self-center text-center bg-transparent mx-auto transform -translate-y-full absolute w-full top-1/7 z-30 font-black px-1.5 py-0.5 justify-center'>

--- a/src/components/TownSquare.tsx
+++ b/src/components/TownSquare.tsx
@@ -208,6 +208,7 @@ export function TownSquare({ players }: { players: ISeatedPlayer[] }) {
     }, [isDraggingControls]);
 
     const N = clamp(players.length, 5, 20);
+    const reminderSlotsPerPlayer = 5;
 
     // Big circle sizing rules (tweakable)
     // "goes about 2/3 way to the vertical edge" -> radius relative to width
@@ -566,6 +567,23 @@ export function TownSquare({ players }: { players: ISeatedPlayer[] }) {
                 const cornerBoost = 1 + viewSettings.tension * Math.pow(Math.abs(Math.sin(2 * angle)), 2);
                 const x = centerX + ringRx * cornerBoost * Math.cos(angle) - tokenSize / 2;
                 const y = centerY + ringRy * cornerBoost * Math.sin(angle) - tokenSize / 2;
+                const tokenCenterX = x + tokenSize / 2;
+                const tokenCenterY = y + tokenSize / 2;
+                const reminderTokenSize = clamp(tokenSize * 0.35, 18, 52);
+                const radialX = tokenCenterX - centerX;
+                const radialY = tokenCenterY - centerY;
+                const radialLength = Math.hypot(radialX, radialY) || 1;
+                const unitRadialX = radialX / radialLength;
+                const unitRadialY = radialY / radialLength;
+                const reminderStart = tokenSize / 2 + reminderTokenSize * 0.6;
+                const reminderSpacing = reminderTokenSize * 0.9;
+                const reminderSlots = Array.from({ length: reminderSlotsPerPlayer }, (_, slotIndex) => {
+                    const distance = reminderStart + slotIndex * reminderSpacing;
+                    return {
+                        x: tokenCenterX + unitRadialX * distance - reminderTokenSize / 2,
+                        y: tokenCenterY + unitRadialY * distance - reminderTokenSize / 2
+                    };
+                });
 
                 const img = (
                     p.alignment === 'good' ?
@@ -595,6 +613,8 @@ export function TownSquare({ players }: { players: ISeatedPlayer[] }) {
                             alignment={alignment}
                             firstNightOrder={nightOrderIndex.first[p.role as Roles] ?? 0}
                             otherNightOrder={nightOrderIndex.other[p.role as Roles] ?? 0}
+                            reminderSlots={reminderSlots}
+                            reminderTokenSize={reminderTokenSize}
                         >
                             <img
                                 src={tokenImg}


### PR DESCRIPTION
### Motivation
- Prepare the UI to place Reminder Tokens around player tokens by computing and exposing slot positions. 
- Ensure reminder slot layout follows the token radial direction so reminders are positioned consistently off-token. 
- Allow the renderer for each character token to reserve space/placeholders for reminder tokens. 

### Description
- Compute per-player radial slot positions in `TownSquare` using `reminderSlotsPerPlayer`, token center, unit radial vector, `reminderStart`, and `reminderSpacing` to build a `reminderSlots` array. 
- Calculate a scaled `reminderTokenSize` with `clamp(tokenSize * 0.35, 18, 52)` and use it when generating slot positions. 
- Add `reminderSlots?: Array<{ x: number; y: number }>` and `reminderTokenSize?: number` props to `CharacterTokenParent` and pass the computed values from `TownSquare`. 
- Render hidden placeholder span elements for each slot inside `CharacterTokenParent` with relative `left`/`top` offsets so reminder tokens can be positioned later. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b205ae09c832ab47815eddfbf0d1f)