### PR TITLE
Refactor game slice types into shared store types

### DIFF
--- a/src/store/game/game-slice.ts
+++ b/src/store/game/game-slice.ts
@@ -1,19 +1,9 @@
 // src/store/game/game-slice.ts
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Roles } from '../../data/types';
 import { toProperCase } from '../../utils/getWordsForNumber.ts/toProperCase';
-import { GameStates } from '../types/game-types';
+import { IGameSlice } from '../types/game-types';
 
 // src/store/game/slice.ts
-export interface IGameSlice {
-    gameID: string;
-    winner?: 'evil' | 'good';
-    day: number;
-    phase: 'day' | 'night';
-    gameState: GameStates;
-    script: Roles[];
-}
-
 export const initialState: IGameSlice = {
     winner: undefined,
     day: 0,

--- a/src/store/types/game-types.ts
+++ b/src/store/types/game-types.ts
@@ -1,1 +1,14 @@
+import { Roles } from '../../data/types';
+
 export type GameStates = 'idle' | 'reveal' | 'in-progress' | 'setup';
+export type GamePhase = 'day' | 'night';
+export type GameWinner = 'evil' | 'good';
+
+export interface IGameSlice {
+    gameID: string;
+    winner?: GameWinner;
+    day: number;
+    phase: GamePhase;
+    gameState: GameStates;
+    script: Roles[];
+}


### PR DESCRIPTION
### Motivation

- Centralize game domain type definitions into `src/store/types` so multiple slices can share them.  
- Reduce `game-slice.ts` responsibilities to state/reducers/selectors only.  
- Make it easier to extract related functionality (e.g., timer or world slices) that reuse the same types.  
- Avoid coupling other slices to implementation files by providing a single source of truth for game types.

### Description

- Added `GamePhase`, `GameWinner`, `IGameSlice` and related aliases to `src/store/types/game-types.ts` and kept `GameStates` there.  
- Updated `src/store/game/game-slice.ts` to import `IGameSlice` from `../types/game-types` and removed the inline `IGameSlice` declaration.  
- Left the `initialState`, reducers and selectors in `game-slice.ts` unchanged so slice logic remains colocated.  
- Did not modify other slices in this change (existing grimoire types remain in `src/store/types/grimoire-types.ts`).

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b20eccc78832a91d66a3eb4c8526c)