### PR TITLE
feat(types): expand personality trait tiers to five-level spectra

### DIFF
--- a/src/store/types/player-types.ts
+++ b/src/store/types/player-types.ts
@@ -83,11 +83,11 @@ export interface IntoxicationWorldModel {
     notes?: string;
 }
 
-export type TrustModels = 'all_trusting' | 'skeptical' | 'doubting_thomas';
-export type TableImpactStyles = 'disruptive' | 'stabilizing' | 'procedural';
-export type ReasoningModes = 'deductive' | 'associative' | 'surface';
-export type InformationHandlingStyle = 'archivist' | 'impressionistic' | 'signal_driven';
-export type VoiceStyles = 'quiet' | 'conversational' | 'dominant';
+export type TrustModels = 'all_trusting' | 'cautiously_trusting' | 'skeptical' | 'guarded' | 'doubting_thomas';
+export type TableImpactStyles = 'disruptive' | 'provocative' | 'stabilizing' | 'organized' | 'procedural';
+export type ReasoningModes = 'deductive' | 'systematic' | 'associative' | 'intuitive' | 'surface';
+export type InformationHandlingStyle = 'archivist' | 'curator' | 'impressionistic' | 'triage' | 'signal_driven';
+export type VoiceStyles = 'quiet' | 'reserved' | 'conversational' | 'assertive' | 'dominant';
 
 export type Personality = {
     trustModel: TrustModels;


### PR DESCRIPTION
### Motivation
- Provide a consistent five-point spectrum for each personality trait so agents and players can express finer-grained behavior. 
- Replace the existing 3-option unions with 5-option unions to allow intermediate and more descriptive tiers. 

### Description
- Updated union types in `src/store/types/player-types.ts` for `TrustModels`, `TableImpactStyles`, `ReasoningModes`, `InformationHandlingStyle`, and `VoiceStyles` to include five options each. 
- Added intermediate tiers such as `cautiously_trusting` / `guarded`, `provocative` / `organized`, `systematic` / `intuitive`, `curator` / `triage`, and `reserved` / `assertive`. 
- Kept the `Personality` type shape intact while changing the referenced unions to the expanded sets. 

### Testing
- Ran `npm run format -- --write src/store/types/player-types.ts`, which completed successfully. 
- No other automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1da16ab8832ab134b2a17011dae0)