### PR TITLE
feat(ui): add town background image

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { TopBar } from './TopBar';
 import { BottomBar } from './BottomBar';
 import { HistoryPanel } from './HistoryPanel';
 import { ViewControlsProvider } from './ViewControlsContext';
+import townBackground from '@/assets/images/town/background.jpg';
 
 export function AppShell({ children }: { children: React.ReactNode }) {
     return (
@@ -19,7 +20,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                         <TopBar />
 
                         {/* This is the remaining usable space */}
-                        <main className='min-h-0 flex-1 overflow-hidden'>{children}</main>
+                        <main
+                            className='min-h-0 flex-1 overflow-hidden bg-transparent bg-cover bg-center'
+                            style={{ backgroundImage: `url(${townBackground})` }}
+                        >
+                            {children}
+                        </main>
 
                         <BottomBar className='bottom-0"' />
                     </div>

--- a/src/components/TownSquare.tsx
+++ b/src/components/TownSquare.tsx
@@ -587,7 +587,7 @@ export function TownSquare({ players }: { players: ISeatedPlayer[] }) {
     return (
         <div
             ref={ref}
-            className='relative h-full w-full overflow-hidden bg-background'
+            className='relative h-full w-full overflow-hidden bg-transparent'
         >
             {isViewControlsOpen && !shouldUseDrawer ?
                 <div


### PR DESCRIPTION
### Motivation
- Apply the town background image to the main content area so the scene shows behind non-UI content.
- Ensure non-UI containers render transparent so the background image is visible through them.
- Keep UI components (TopBar, BottomBar, Sidebar) visually intact and still using their UI backgrounds.

### Description
- Import the image `src/assets/images/town/background.jpg` in `src/components/AppShell.tsx` and set it as the `backgroundImage` on the main element with classes `bg-transparent bg-cover bg-center`.
- Replace `bg-background` with `bg-transparent` on the TownSquare root container in `src/components/TownSquare.tsx` so the main background shows through.
- No changes were made to TopBar, BottomBar, or Sidebar styling so UI components retain their original backgrounds.

### Testing
- Ran the dev server with `npm run dev` and captured a Playwright screenshot which shows the applied background at `artifacts/town-background.png`.
- The dev server startup produced Vite/esbuild transform errors from unrelated JSX parse issues in `src/components/CharacterTokenParent.tsx`, so a full successful build was not completed.
- No Jest tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c27f1f064832a8d9017f59e034c60)