### PR TITLE
feat(ui): add grimoire shape preference

### DIFF
--- a/src/components/top-bar/TopBarPreferencesDialog.tsx
+++ b/src/components/top-bar/TopBarPreferencesDialog.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 import { Switch } from '@/components/ui/switch';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Settings } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
+    selectGrimoireShape,
     selectShowFirstNightOrder,
     selectShowNightOrder,
     selectShowOtherNightOrder,
+    setGrimoireShape,
     setShowFirstNightOrder,
     setShowNightOrder,
     setShowOtherNightOrder
@@ -15,6 +18,7 @@ import {
 
 export function TopBarPreferencesDialog() {
     const dispatch = useAppDispatch();
+    const grimoireShape = useAppSelector(selectGrimoireShape);
     const showNightOrder = useAppSelector(selectShowNightOrder);
     const showFirstNightOrder = useAppSelector(selectShowFirstNightOrder);
     const showOtherNightOrder = useAppSelector(selectShowOtherNightOrder);
@@ -40,6 +44,32 @@ export function TopBarPreferencesDialog() {
                     <DialogDescription>Adjust game UI visibility settings.</DialogDescription>
                 </DialogHeader>
                 <div className='space-y-4'>
+                    <div className='border-b border-border/60 pb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
+                        Preferences
+                    </div>
+                    <div className='flex flex-wrap items-center justify-between gap-4'>
+                        <div>
+                            <div className='text-sm font-semibold'>Grimoire shape</div>
+                            <div className='text-xs text-muted-foreground'>
+                                Choose the layout shape for the grimoire board.
+                            </div>
+                        </div>
+                        <ToggleGroup
+                            type='single'
+                            value={grimoireShape}
+                            variant='outline'
+                            size='sm'
+                            spacing={0}
+                            onValueChange={(value) => {
+                                if (value) {
+                                    dispatch(setGrimoireShape(value as typeof grimoireShape));
+                                }
+                            }}
+                        >
+                            <ToggleGroupItem value='circle'>Circle</ToggleGroupItem>
+                            <ToggleGroupItem value='square'>Square</ToggleGroupItem>
+                        </ToggleGroup>
+                    </div>
                     <div className='border-b border-border/60 pb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
                         Night order badges
                     </div>

--- a/src/store/settings/settings-slice.ts
+++ b/src/store/settings/settings-slice.ts
@@ -5,12 +5,14 @@ export interface SettingsState {
     showNightOrder: boolean;
     showFirstNightOrder: boolean;
     showOtherNightOrder: boolean;
+    grimoireShape: 'circle' | 'square';
 }
 
 const initialState: SettingsState = {
     showNightOrder: true,
     showFirstNightOrder: true,
-    showOtherNightOrder: true
+    showOtherNightOrder: true,
+    grimoireShape: 'circle'
 };
 
 export const settingsSlice = createSlice({
@@ -25,17 +27,25 @@ export const settingsSlice = createSlice({
         },
         setShowOtherNightOrder: (state, action: PayloadAction<boolean>) => {
             state.showOtherNightOrder = action.payload;
+        },
+        setGrimoireShape: (state, action: PayloadAction<SettingsState['grimoireShape']>) => {
+            state.grimoireShape = action.payload;
         }
     },
     selectors: {
         selectShowNightOrder: (state) => state.showNightOrder,
         selectShowFirstNightOrder: (state) => state.showFirstNightOrder,
-        selectShowOtherNightOrder: (state) => state.showOtherNightOrder
+        selectShowOtherNightOrder: (state) => state.showOtherNightOrder,
+        selectGrimoireShape: (state) => state.grimoireShape
     }
 });
 
-export const { setShowNightOrder, setShowFirstNightOrder, setShowOtherNightOrder } =
+export const { setShowNightOrder, setShowFirstNightOrder, setShowOtherNightOrder, setGrimoireShape } =
     settingsSlice.actions;
 
-export const { selectShowNightOrder, selectShowFirstNightOrder, selectShowOtherNightOrder } =
-    settingsSlice.selectors;
+export const {
+    selectShowNightOrder,
+    selectShowFirstNightOrder,
+    selectShowOtherNightOrder,
+    selectGrimoireShape
+} = settingsSlice.selectors;


### PR DESCRIPTION
### Motivation
- Expose a user preference to change the grimoire board layout between circle and square shapes for improved UI configurability.
- Persist the selected shape in the app settings so other components can read and render accordingly.

### Description
- Add `grimoireShape: 'circle' | 'square'` to `SettingsState` with default `'circle'` in `src/store/settings/settings-slice.ts`.
- Add `setGrimoireShape` reducer and `selectGrimoireShape` selector to the settings slice and export them.
- Add a `Grimoire shape` control to the Preferences section of `src/components/top-bar/TopBarPreferencesDialog.tsx` using the existing `ToggleGroup`/`ToggleGroupItem` UI, wired to `selectGrimoireShape` and `setGrimoireShape` with short helper text.

### Testing
- Ran the dev server with `npm run dev`, which started but showed a build error from an unrelated JSX parse issue (esbuild) preventing a clean full run.
- Attempted UI verification via Playwright screenshot, but the Chromium process crashed (SIGSEGV) in this environment so the screenshot could not be captured.
- Ran the formatter with `npm run format`, which failed in this environment due to Prettier requiring file/glob arguments rather than indicating code formatting issues.
- Changes were committed locally as `feat(ui): add grimoire shape preference` (no unit tests were added or run for this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c296c0ae0832a83ed88c300d2abe7)