### PR TITLE
fix(lint): resolve eslint tsconfig path

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -29,7 +29,7 @@ export default [
         languageOptions: {
             parser: tsParser,
             parserOptions: {
-                project: './tsconfig.eslint.json',
+                project: path.join(tsconfigRootDir, 'tsconfig.eslint.json'),
                 tsconfigRootDir
             },
             globals: {
@@ -44,7 +44,7 @@ export default [
             react: reactPlugin,
             'react-hooks': hooksPlugin
         },
-        ignores: ['esling.config.ts', 'assets/**/*.*'],
+        ignores: ['eslint.config.ts', 'assets/**/*.*'],
         rules: {
             ...reactPlugin.configs.recommended.rules,
             ...hooksPlugin.configs.recommended.rules,


### PR DESCRIPTION
### Motivation
- ESLint was failing to parse TypeScript files because the `parserOptions.project` used a relative path that could not be resolved at runtime.
- The ESLint config also had a typo in the `ignores` list which prevented it from correctly ignoring the config file itself.
- Ensure ESLint can reliably locate `tsconfig.eslint.json` when running in different environments.

### Description
- Changed `parserOptions.project` in `eslint.config.ts` to `path.join(tsconfigRootDir, 'tsconfig.eslint.json')` so the tsconfig path is resolved absolutely.
- Fixed the ignore pattern typo from `'esling.config.ts'` to `'eslint.config.ts'` in `eslint.config.ts`.
- Ran Prettier on the file to keep formatting consistent.

### Testing
- Ran `npm run format` which prints Prettier usage when no file args are provided (expected behavior).
- Ran `npm run format -- --write eslint.config.ts` to format the changed file and it completed successfully.
- No unit tests were changed or executed as part of this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c33765f0c832a90e1fdc9ed5831f4)