### PR TITLE
feat(prompts): compact PromptSpec and convert outputs to schema factories

### DIFF
--- a/src/prompts/_genericStorytellerCore.ts
+++ b/src/prompts/_genericStorytellerCore.ts
@@ -5,22 +5,16 @@
  */
 export const genericStorytellerCore = {
     instructions: [
-        `You are an expert Storyteller for Blood on the Clocktower.`,
-        `Your goal is to determine what information to present to Good information roles, balancing truth, misinformation, and long-term deduction integrity.`,
-        `You are not optimizing for correctness alone. You are optimizing for meaningful uncertainty within legal outcomes.`
+        `You are the Storyteller for Blood on the Clocktower.`,
+        `Follow the Pandemonium Institute wiki rules and role text.`,
+        `Give legal information that preserves meaningful uncertainty.`
     ],
     guidelines: [
-        `BALANCE: Correct information should advance deduction without instantly solving the game. Incorrect information should mislead without soft-locking Good into impossibility.`,
-        `CONSISTENCY: The result must remain mechanically defensible within the rules. Do not create outcomes that require post-hoc excuses.`,
-        `MISREGISTRATION: Consider false registration (e.g. Recluse, Spy) deliberately. Use this power sparingly and intentionally—not as default spice.`,
-        `RECLUSE LIMIT: If the Recluse is Drunk or Poisoned, the Recluse cannot misregister.`,
-        `SOBRIETY & HEALTH: If the information role is Drunk or Poisoned, their information may be incorrect. Incorrect does not mean random—false info should still form coherent and discussable worlds.`,
-        `DRAMA OVER TIME: Prefer outcomes that stay relevant for multiple days/nights rather than collapsing instantly.`,
-        `PLAYER EXPERIENCE: Avoid outputs that feel like “ST nonsense” unless your group explicitly loves that style.`
+        `Keep outcomes legal, coherent, and explainable.`,
+        `Use misregistration (Recluse/Spy) only when rules allow; avoid overuse.`,
+        `If drunk/poisoned, wrong info should still create plausible worlds.`,
+        `Favor results that keep multiple worlds alive for several turns.`,
+        `Avoid results that feel arbitrary or unfair.`
     ],
-    footnote: `You may show true information to a drunk/poisoned player or false information to a sober/healthy player, as long as the result is legal and supports the game. The rules define legality; Storytelling defines quality.`,
-    quote: [
-        `A good Storyteller doesn’t ask “Is this true?”`,
-        `They ask “What does this force the table to wrestle with next?”`
-    ]
+    footnote: `Use legal ambiguity to support a fun, solvable game.`
 };

--- a/src/prompts/chefNumber.ts
+++ b/src/prompts/chefNumber.ts
@@ -11,34 +11,18 @@ export const chefNumber: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Determine the Chef's number: the count of immediately adjacent pairs of Evil players sitting next to each other (seating is circular). Examine the seating like a linked list with the highest number seat connecting back to 1. Go through the list and calculate the number of evil immediate pairs (any good players in between break up the pairs). So, if for example, it went 1-monk, 2-imp, 3-saint, 4-baron, the correct count would be 0 whereas 1-recluse (good, but misregisters), 2-imp (evil), 3-saint (good), 4-baron (evil) could be either 2, or 0 depending on if we counted the recluse as evil in this example.`,
+    goal: `Return the Chef number: adjacent Evil-Evil pairs around a circular seating.`,
 
     additionalConsiderations: [
-        `SEATING IS CIRCULAR: The last seat is adjacent to seat 0.`,
-        `ADJACENT PAIRS ARE THOSE IMMEDIATELY ADJACENT: Meaning that seat 3 and 4 being evil is a pair, seat 3 and 5 being evil is not a pair, unless 4 is evil as well and then that would be 2 pairs (3 and 4 & 4 and 5)`,
-        `COUNTING RULE: Each adjacent Evil-Evil connection counts as 1 pair. Three Evils in a row produces 2 pairs.`,
-        `MISREGISTRATION: Recluse may register as Evil; Spy may register as Good. Apply selectively to create useful ambiguity.`,
-        `SOBER/HEALTHY CHEF: Default to the true count unless you have a strong reason to deviate legally.`,
-        `DRUNK/POISONED CHEF: If giving an incorrect count, prefer a nearby number that still generates plausible seating worlds.`,
-        `PATTERN QUALITY: Aim for a number that creates multiple competing seating theories rather than a single dominant solve.`
+        `Use circular adjacency (last seat adjacent to 1).`,
+        `Recluse/Spy misregistration only if legal.`,
+        `If drunk/poisoned, give a nearby plausible number.`,
+        `Prefer results that keep multiple worlds alive.`
     ],
 
-    input: [
-        `Seating order with seat numbers`,
-        `Full grimoire (including actual alignments, and whether Recluse/Spy are in play)`,
-        `Chef sober/healthy state`
-    ],
+    input: [`Seating order`, `Grimoire (alignments + misregistration roles)`, `Chef sobriety/health`],
 
-    output: {
-        count: "number (Chef's reported adjacent Evil pair count)",
-        reasoning: {
-            type: 'string',
-            description:
-                'Brief ST philosophy explaining the choice, including any misregistration and/or sobriety considerations.'
-        }
-    },
-
-    schema: {
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'ChefNumberOutput',
         type: 'object',
@@ -46,16 +30,17 @@ export const chefNumber: PromptSpec = {
         required: ['count', 'reasoning'],
         properties: {
             count: {
-                type: 'number',
+                type: 'integer',
                 minimum: 0,
-                maximum: 6,
-                description: 'The chefs reported adjacent Evil pair count.'
+                maximum: Math.max(1, playerCount),
+                description: 'Chef’s reported adjacent Evil pair count.'
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'Brief ST philosophy explaining the choice, including any misregistration and/or sobriety considerations.'
+                minLength: 1,
+                maxLength: 200,
+                description: 'Why this count is legal and useful.'
             }
         }
-    }
+    })
 };

--- a/src/prompts/claimPlanner.ts
+++ b/src/prompts/claimPlanner.ts
@@ -2,105 +2,76 @@
 import { PromptSpec } from './prompt-types';
 
 /**
- * Universal “claim planning” prompt for any AI player.
- * Works for:
- * - Evil (Imp + Minions) planning bluffs with imperfect knowledge of out-of-play
- * - Good (Townsfolk/Outsider) choosing to hard-claim or build a bluff stack
- *
- * Key behaviors:
- * - Produces 3 “lanes” (1-for-1, 2-for-2, 3-for-3 sharing)
- * - Includes pivot rules when contradictions appear
- * - Explicitly models “unknown out-of-play” risk
+ * Universal claim-planning prompt for any AI player.
  */
 export const claimPlanner: PromptSpec = {
     id: 'player-claim-planner',
     version: '1.0',
-    title: 'Player – Claim & Bluff Planning (3-Lane)',
+    title: 'Player – Claim & Bluff Planning',
     tags: ['botc', 'player', 'social', 'claims', 'bluffs'],
     perspective: 'player',
 
     instructions: [
-        `You are an AI player in Blood on the Clocktower.`,
-        `Your task is to plan a claim strategy: either claim your real role or prepare believable bluffs.`,
-        `You must output THREE claim lanes to support “1-for-1”, “2-for-2”, and “3-for-3” trust trades.`,
-        `You do not know everything that is out of play. You must explicitly manage what is safe to claim now vs later.`,
-        `You should also output a pivot plan for when your claim becomes unsafe or contradicted.`
+        `You are a player in Blood on the Clocktower.`,
+        `Plan a claim strategy with three lanes (light, medium, full).`,
+        `Follow PI wiki rules and your personality.`
     ],
 
     guidelines: [
-        `BELIEVABILITY: Claims must match your seat context, public info, night/day timing, and your personality.`,
-        `RISK: Powerful roles attract kills; weak roles attract suspicion. Choose your exposure deliberately.`,
-        `SAFE-TO-CLAIM VS SAFE-TO-HOLD: Before you know what’s out of play, avoid claims that will collapse from basic checks.`,
-        `TRADECRAFT: Your 3 lanes should scale: lane 1 is low-commitment, lane 2 adds detail, lane 3 is fully committed with a story.`,
-        `PIVOTING: Predefine when to switch claims (e.g., when a hard counter-claim appears, or a mechanical contradiction is announced).`,
-        `PERSONALITY CONSISTENCY: A bold personality may hard-claim early; a cautious personality may delay and hedge.`
+        `Keep claims believable for the public state.`,
+        `Avoid claims that collapse if out-of-play is unknown.`,
+        `Define a pivot if contradicted.`,
+        `Scale details across the three lanes.`
     ],
 
-    footnote: `A claim is not only a role label—it is a long-term story. The best stories survive cross-examination.`,
+    footnote: `A claim is a long-term story.`,
 
-    goal: `Produce a 3-lane claim plan (including whether to tell the truth), plus pivot rules and a conversation to-do list for tomorrow.`,
+    goal: `Produce a 3-lane claim plan with pivots and next talks.`,
 
     additionalConsiderations: [
-        `GOOD ROLES: If you are a high-value target (Fortune Teller, Empath, Undertaker, Monk, Mayor), consider bluffing something less appetizing until you’ve extracted value.`,
-        `GOOD BAIT: If your role is likely to die soon or be nominated (first-night roles, Ravenkeeper, Virgin), bluffing stronger can deter kills or redirect nominations.`,
-        `EVIL (IMP/MINIONS): Early game may be pre-bluffs (before official demon bluffs are known). Prefer resilient claims that don’t require exact out-of-play knowledge.`,
-        `PIVOT TRIGGERS: A pivot should be planned around common collision points: hard counter-claims, Undertaker reveals, Investigator/Librarian pings, or a sudden no-death night.`,
-        `TRADE PROTOCOLS: In “1-for-1”, keep it vague; in “2-for-2”, add a detail; in “3-for-3”, give full timeline + reasoning.`
+        `Good: hide high-value roles if needed.`,
+        `Evil: prefer resilient claims before bluffs are known.`,
+        `Trade: lane 1 vague, lane 2 adds detail, lane 3 full timeline.`
     ],
 
     personalityModulation: {
         trustModel: {
-            all_trusting: `Share earlier and more fully; assume others reciprocate until they don’t.`,
-            skeptical: `Share selectively; trade info for info.`,
-            doubting_thomas: `Assume others are fishing; hold details back until necessary.`
+            all_trusting: `Share earlier and more fully.`,
+            skeptical: `Trade info for info.`,
+            doubting_thomas: `Hold details until forced.`
         },
         tableImpact: {
-            disruptive: `Use claims to shake the table—bait reactions and force commitments.`,
-            stabilizing: `Use claims to build a coherent coalition and reduce chaos.`,
-            procedural: `Use claims that are mechanically tight and easy to defend.`
+            disruptive: `Bait reactions with bold claims.`,
+            stabilizing: `Build a steady coalition.`,
+            procedural: `Use mechanically tight claims.`
         },
         reasoningMode: {
-            deductive: `Prefer claims that fit constraints and survive mechanical cross-checks.`,
-            associative: `Prefer claims that fit the social narrative and group psychology.`,
-            surface: `Prefer simple, obvious claims and avoid complex stories early.`
+            deductive: `Pick claims that fit constraints.`,
+            associative: `Fit the social narrative.`,
+            surface: `Keep claims simple early.`
         },
         informationHandling: {
-            archivist: `Include precise timelines (Day/Night numbers) and preserve consistency across lanes.`,
-            impressionistic: `Keep it conversational; focus on conclusions over exact details.`,
-            signal_driven: `Adjust lanes to what the table is currently focused on.`
+            archivist: `Track timelines and consistency.`,
+            impressionistic: `Prioritize conversation flow.`,
+            signal_driven: `Adjust to the table focus.`
         },
         voiceStyle: {
-            quiet: `Start with lane 1; reveal lane 2/3 only if pressured or trading.`,
-            conversational: `Use lane escalation naturally in talks.`,
-            dominant: `Pick a lane and drive the narrative; pivot decisively if needed.`
+            quiet: `Reveal lanes gradually.`,
+            conversational: `Escalate naturally in talks.`,
+            dominant: `Drive a clear narrative.`
         }
     },
 
     input: [
-        `Your seat number and actual role`,
-        `Your alignment (Good/Evil)`,
-        `For Evil: demon/minion info (if available) and whether official demon bluffs are known yet`,
-        `Public claims and rumors so far`,
-        `Your suspicion map`,
-        `Any private info you actually have (e.g., spy grimoire access, investigator ping, fortune teller results)`,
-        `Night/Day count`,
-        `Your personality profile`
+        `Your seat + role + alignment`,
+        `Evil info if applicable`,
+        `Public claims and rumors`,
+        `Your private info`,
+        `Night/day count`,
+        `Personality profile`
     ],
 
-    output: {
-        shown: `object: {
-      truthPolicy: "truth" | "bluff" | "hybrid",
-      lane1: { role: string, details: string },
-      lane2: { role: string, details: string },
-      lane3: { role: string, details: string },
-      backupRoles: string[]
-    }`,
-        pivot: `object: { triggers: string[], nextClaim: { role: string, details: string } }`,
-        todos: 'number[] (seat numbers to talk to tomorrow, in priority order)',
-        reasoning: 'In-character explanation tying the chosen strategy to risk, table state, and personality.'
-    },
-
-    schema: {
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'ClaimPlannerOutput',
         type: 'object',
@@ -109,47 +80,149 @@ export const claimPlanner: PromptSpec = {
         properties: {
             shown: {
                 type: 'object',
+                description: 'Three-lane claim plan.',
                 additionalProperties: false,
                 required: ['truthPolicy', 'lane1', 'lane2', 'lane3', 'backupRoles'],
                 properties: {
-                    truthPolicy: { type: 'string', enum: ['truth', 'bluff', 'hybrid'] },
+                    truthPolicy: {
+                        type: 'string',
+                        enum: ['truth', 'bluff', 'hybrid'],
+                        minLength: 4,
+                        maxLength: 6,
+                        description: 'Truthfulness strategy.'
+                    },
                     lane1: {
                         type: 'object',
+                        description: 'Light claim lane.',
                         additionalProperties: false,
                         required: ['role', 'details'],
-                        properties: { role: { type: 'string' }, details: { type: 'string' } }
+                        properties: {
+                            role: {
+                                type: 'string',
+                                minLength: 2,
+                                maxLength: 30,
+                                description: 'Claimed role label.'
+                            },
+                            details: {
+                                type: 'string',
+                                minLength: 3,
+                                maxLength: 160,
+                                description: 'Minimal details for lane 1.'
+                            }
+                        }
                     },
                     lane2: {
                         type: 'object',
+                        description: 'Medium claim lane.',
                         additionalProperties: false,
                         required: ['role', 'details'],
-                        properties: { role: { type: 'string' }, details: { type: 'string' } }
+                        properties: {
+                            role: {
+                                type: 'string',
+                                minLength: 2,
+                                maxLength: 30,
+                                description: 'Claimed role label.'
+                            },
+                            details: {
+                                type: 'string',
+                                minLength: 3,
+                                maxLength: 200,
+                                description: 'Moderate details for lane 2.'
+                            }
+                        }
                     },
                     lane3: {
                         type: 'object',
+                        description: 'Full claim lane.',
                         additionalProperties: false,
                         required: ['role', 'details'],
-                        properties: { role: { type: 'string' }, details: { type: 'string' } }
+                        properties: {
+                            role: {
+                                type: 'string',
+                                minLength: 2,
+                                maxLength: 30,
+                                description: 'Claimed role label.'
+                            },
+                            details: {
+                                type: 'string',
+                                minLength: 3,
+                                maxLength: 240,
+                                description: 'Full details for lane 3.'
+                            }
+                        }
                     },
-                    backupRoles: { type: 'array', items: { type: 'string' }, minItems: 0 }
+                    backupRoles: {
+                        type: 'array',
+                        minItems: 0,
+                        maxItems: 6,
+                        description: 'Backup claim roles.',
+                        items: {
+                            type: 'string',
+                            minLength: 2,
+                            maxLength: 30,
+                            description: 'Backup role label.'
+                        }
+                    }
                 }
             },
             pivot: {
                 type: 'object',
+                description: 'When and how to pivot.',
                 additionalProperties: false,
                 required: ['triggers', 'nextClaim'],
                 properties: {
-                    triggers: { type: 'array', items: { type: 'string' } },
+                    triggers: {
+                        type: 'array',
+                        minItems: 1,
+                        maxItems: 6,
+                        description: 'Events that trigger a pivot.',
+                        items: {
+                            type: 'string',
+                            minLength: 4,
+                            maxLength: 120,
+                            description: 'Pivot trigger.'
+                        }
+                    },
                     nextClaim: {
                         type: 'object',
+                        description: 'Claim to pivot to.',
                         additionalProperties: false,
                         required: ['role', 'details'],
-                        properties: { role: { type: 'string' }, details: { type: 'string' } }
+                        properties: {
+                            role: {
+                                type: 'string',
+                                minLength: 2,
+                                maxLength: 30,
+                                description: 'Pivot role label.'
+                            },
+                            details: {
+                                type: 'string',
+                                minLength: 3,
+                                maxLength: 200,
+                                description: 'Pivot details.'
+                            }
+                        }
                     }
                 }
             },
-            todos: { type: 'array', items: { type: 'number' } },
-            reasoning: { type: 'string' }
+            todos: {
+                type: 'array',
+                minItems: 0,
+                maxItems: Math.max(1, playerCount),
+                description: 'Seats to talk to next, in priority order.',
+                items: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: Math.max(1, playerCount),
+                    description: 'Seat to prioritize.'
+                }
+            },
+            reasoning: {
+                type: 'string',
+                minLength: 1,
+                maxLength: 260,
+                description: 'Why this claim plan fits the state and personality.'
+            }
         }
-    }
+    })
 };

--- a/src/prompts/createPrompt.ts
+++ b/src/prompts/createPrompt.ts
@@ -46,8 +46,7 @@ export function createPrompt(
         inputs,
         personalityModulation,
         title,
-        tags,
-        schema
+        tags
     } = promptSpec;
     const { personality } = opts ?? { personality: undefined };
     const addBullet = (s: string) => `* ${s}`;
@@ -86,11 +85,7 @@ export function createPrompt(
         ...(inputs?.map(addBullet) ?? []),
         '',
         'OUTPUT:',
-        JSON.stringify(
-            typeof schema === 'function' ? schema({ playerCount: extractedSeats.length }) : schema,
-            null,
-            '\t'
-        ),
+        JSON.stringify(output({ playerCount: extractedSeats.length }), null, '\t'),
         ''
     ];
 

--- a/src/prompts/demonBluffs.ts
+++ b/src/prompts/demonBluffs.ts
@@ -11,33 +11,17 @@ export const demonBluffs: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Select three out-of-play characters to serve as Demon bluffs, empowering Evil lies while preserving counterplay.`,
+    goal: `Pick three out-of-play roles as Demon bluffs that enable lies without collapsing solvability.`,
 
     additionalConsiderations: [
-        `COVERAGE: Provide three bluffs that support different lie styles (early claim, reactive defense, late pivot).`,
-        `PLAUSIBILITY: Bluffs must survive basic mechanical scrutiny given the current setup.`,
-        `COUNTERPLAY: Good should be able to interrogate claims without instant collapse.`,
-        `PLAYER EXPERIENCE: Match bluff complexity to the Demon’s expected comfort level.`,
-        `ONLY PICK FROM THE OUT OF PLAY BLUFFS PROVIDED`
+        `Cover early, mid, and late claim paths.`,
+        `Ensure each bluff is mechanically plausible on this script.`,
+        `Only pick from the out-of-play list.`
     ],
 
-    input: [
-        `Full grimoire`,
-        `Full list of out-of-play characters`,
-        `Script context (demon type, minions, outsider count)`,
-        `Optional player experience notes`
-    ],
+    input: [`Grimoire`, `Out-of-play roles list`, `Script context`, `Player experience notes (optional)`],
 
-    output: {
-        shown: 'object: { roles: [string, string, string] } (the three bluff roles)',
-        reasoning: {
-            type: 'string',
-            description:
-                'Brief ST philosophy explaining why this bluff set supports Evil while preserving a playable deduction space. Limit to 2 sentences max, preferably 1.'
-        }
-    },
-
-    schema: {
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'DemonBluffsOutput',
         type: 'object',
@@ -46,24 +30,31 @@ export const demonBluffs: PromptSpec = {
         properties: {
             shown: {
                 type: 'object',
+                description: 'The chosen bluff payload.',
                 additionalProperties: false,
                 required: ['roles'],
                 properties: {
                     roles: {
                         type: 'array',
+                        description: 'Exactly three out-of-play bluff roles.',
                         minItems: 3,
                         maxItems: 3,
-                        items: { type: 'string' },
-                        description: 'The three bluff roles chosen - must be out of play and on the script.',
-                        enum: playerRoles
+                        items: {
+                            type: 'string',
+                            enum: playerRoles,
+                            minLength: 2,
+                            maxLength: 30,
+                            description: 'Role name from the script.'
+                        }
                     }
                 }
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'Brief ST philosophy explaining why this bluff set supports Evil while preserving a playable deduction space. Limit to 2 sentences max, preferably 1.'
+                description: 'Why these bluffs help Evil while keeping counterplay.',
+                minLength: 1,
+                maxLength: 240
             }
         }
-    }
+    })
 };

--- a/src/prompts/drunkChoice.ts
+++ b/src/prompts/drunkChoice.ts
@@ -11,32 +11,17 @@ export const drunkChoice: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Select which TOWNSFOLK player is made Drunk during setup, seeding long-term misinformation without collapsing deduction.`,
+    goal: `Choose the Townsfolk player who is the Drunk.`,
 
     additionalConsiderations: [
-        `DURATION: Prefer a Drunk choice whose incorrect info compounds over multiple days rather than resolving instantly.`,
-        `FAIRNESS: Avoid making the Drunk a role whose failure immediately hard-confirms Evil or creates an unsolvable mess.`,
-        `SCRIPT SYNERGY: Align the Drunk with expected poison/madness/bluff pressures already in the script.`,
-        `PLAYER EXPERIENCE: Prefer a player who will engage thoughtfully with bad info (avoid brand-new players unless your group enjoys it).`,
-        `THE DRUNKED ROLE must be a TOWNSFOLK`
+        `Pick a role where bad info creates long-term tension.`,
+        `Avoid hard-confirming or unsolvable outcomes.`,
+        `Must be a Townsfolk.`
     ],
 
-    input: [
-        `Full grimoire (setup state)`,
-        `Script context (roles included, outsider count logic)`,
-        `Optional player experience notes`
-    ],
+    input: [`Setup grimoire`, `Script context`, `Player experience notes (optional)`],
 
-    output: {
-        shown: 'object: { seat: number } (the seat made Drunk)',
-        reasoning: {
-            type: 'string',
-            description:
-                'Brief ST philosophy explaining balance, longevity, and expected misinformation arc. Limit to 2 sentences max, preferably 1.'
-        }
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'DrunkChoiceOutput',
         type: 'object',
@@ -45,21 +30,23 @@ export const drunkChoice: PromptSpec = {
         properties: {
             shown: {
                 type: 'object',
+                description: 'Chosen Drunk seat.',
                 additionalProperties: false,
                 required: ['seat'],
                 properties: {
                     seat: {
-                        type: 'number',
+                        type: 'integer',
                         minimum: 1,
-                        maximum: playerCount,
-                        description: 'The seat # of the player made drunk. Must be a townsfolk.'
+                        maximum: Math.max(1, playerCount),
+                        description: 'Seat made Drunk (must be Townsfolk).'
                     }
                 }
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'Brief ST philosophy explaining balance, longevity, and expected misinformation arc. Limit to 2 sentences max, preferably 1.'
+                minLength: 1,
+                maxLength: 220,
+                description: 'Why this Drunk choice fits the setup.'
             }
         }
     })

--- a/src/prompts/empathNumber.ts
+++ b/src/prompts/empathNumber.ts
@@ -11,45 +11,36 @@ export const empathNumber: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Determine the Empath's number tonight: the count of Evil among the Empath's two LIVING neighbors (0, 1, or 2).`,
+    goal: `Return the Empath number: Evil among the two living neighbors (0-2).`,
 
     additionalConsiderations: [
-        `LIVING ONLY: Only living neighbors are counted.`,
-        `MISREGISTRATION: Recluse may register as Evil; Spy may register as Good. Use this to shape uncertainty, not to create chaos.`,
-        `SOBER/HEALTHY EMPATH: Default to the true count unless you have a strong legal reason to deviate.`,
-        `DRUNK/POISONED EMPATH: If giving an incorrect number, keep it plausible and pattern-friendly across nights.`,
-        `ANTI-TELEGRAPH: Avoid results that scream “poisoned” unless you intentionally want that tension.`
+        `Count living neighbors only.`,
+        `Recluse/Spy misregistration only if legal.`,
+        `If drunk/poisoned, give a plausible value.`,
+        `Avoid neon “poisoned” signals unless intentional.`
     ],
 
-    input: [
-        `Empath seat number and its two neighbors (including living/dead status)`,
-        `Full grimoire`,
-        `Empath sober/healthy state`,
-        `Night number and prior Empath results (if any)`
-    ],
+    input: [`Empath seat + living neighbors`, `Grimoire`, `Empath sobriety/health`, `Night number`],
 
-    output: {
-        count: "number (Empath's reported Evil neighbor count: 0, 1, or 2)",
-        reasoning: {
-            type: 'string',
-            description:
-                'Brief ST philosophy explaining the result, including misregistration and sobriety considerations.'
-        }
-    },
-
-    schema: {
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'EmpathNumberOutput',
         type: 'object',
         additionalProperties: false,
         required: ['count', 'reasoning'],
         properties: {
-            count: { type: 'number', minimum: 0, maximum: 2, description: 'Empaths reported evil neighbor count.' },
+            count: {
+                type: 'integer',
+                minimum: 0,
+                maximum: 2,
+                description: 'Empath’s reported Evil neighbor count.'
+            },
             reasoning: {
                 type: 'string',
-                description:
-                    'Brief ST philosophy explaining the result, including misregistration and sobriety considerations.'
+                minLength: 1,
+                maxLength: 200,
+                description: 'Why this value is legal and helpful.'
             }
         }
-    }
+    })
 };

--- a/src/prompts/fortuneTellerInfo.ts
+++ b/src/prompts/fortuneTellerInfo.ts
@@ -9,52 +9,35 @@ export const fortuneTellerInfo: PromptSpec = {
     perspective: 'storyteller',
 
     instructions: [
-        'You are the Storyteller for a game of Blood on the Clocktower.',
-        'The Fortune Teller has selected two seats to check tonight.',
-        'You must decide whether the Fortune Teller receives a YES or NO result.',
-        'This decision is made with full knowledge of the grimoire, Red Herring assignment, and any drunk or poisoned effects.',
-        'Your response should follow the rules of the Fortune Teller ability while supporting a fair, tense, and narratively coherent game.'
+        'You are the Storyteller for Blood on the Clocktower.',
+        'Adjudicate the Fortune Teller YES/NO using the PI wiki rules.',
+        'Consider Red Herring, misregistration, and drunkenness.'
     ],
 
     guidelines: [
-        'RULE ADHERENCE: If either chosen seat is the Demon, the correct result is YES unless interference applies.',
-        'RED HERRING: If one of the chosen seats is the Red Herring, you may return a YES even if neither seat is the Demon.',
-        'DRUNK / POISON: If the Fortune Teller is drunk or poisoned, the result may be arbitrary, but should still feel plausible.',
-        'MISREGISTRATION: Recluse may register as the Demon and cause a YES result even when not Evil.',
-        'CONSISTENCY OVER TIME: Results should not unintentionally collapse all plausible worlds unless the game state demands it.',
-        'PLAYER TRUST: Avoid results that feel erratic or vindictive without a clear mechanical explanation.'
+        'If a chosen seat is Demon, answer YES unless legal interference.',
+        'Red Herring or Recluse may justify YES.',
+        'If drunk/poisoned, be plausible and consistent over time.',
+        'Avoid results that hard-solve the game early.'
     ],
 
-    goal: 'Determine whether the Fortune Teller receives a YES or NO result that is mechanically valid, narratively coherent, and appropriate for the current game state.',
+    goal: 'Return a legal YES/NO that supports a solvable game.',
 
     additionalConsiderations: [
-        'WORLD PRESERVATION: Prefer results that preserve multiple plausible worlds rather than instantly solving the game.',
-        'RED HERRING MANAGEMENT: Use the Red Herring to introduce uncertainty gradually; avoid overusing it in a way that becomes obvious.',
-        'POISON SIGNALING: If the Fortune Teller is poisoned or drunk, consider whether this night’s result should hint at corruption or remain quietly misleading.',
-        'TIMING MATTERS: Early-game YES results create paranoia; late-game YES results can be decisive.',
-        'SOCIAL CONTEXT: Consider how the town is likely to interpret this result given existing claims and suspicions.',
-        'AVOID HARD CONFIRMATION: Be cautious about giving results that hard-confirm or hard-clear multiple players simultaneously unless appropriate.'
+        'Use Red Herring sparingly and not in a pattern.',
+        'Consider timing and current public narratives.',
+        'If poisoned, decide whether to hint or hide.'
     ],
 
     input: [
-        'Full current grimoire (including Demon seat, Red Herring seat, reminder tokens, alive/dead status)',
-        'Current day and night number',
-        'Fortune Teller seat number',
-        'Whether the Fortune Teller is sober and healthy',
-        'Two seat numbers chosen by the Fortune Teller',
-        'Public claims and relevant narrative context'
+        'Grimoire (Demon + Red Herring + reminders)',
+        'Current day/night',
+        'Fortune Teller seat and sobriety',
+        'Two chosen seats',
+        'Public context'
     ],
 
-    output: {
-        shown: "One of: 'YES' | 'NO'",
-        reasoning: {
-            type: 'string',
-            description:
-                'A brief Storyteller explanation describing the mechanical and narrative factors that justified this result. Limit 2 sentences prefer 1.'
-        }
-    },
-
-    schema: {
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'FortuneTellerResponse',
         type: 'object',
@@ -63,14 +46,14 @@ export const fortuneTellerInfo: PromptSpec = {
         properties: {
             shown: {
                 type: 'boolean',
-                description:
-                    'The fortune tellers reported answer for the two seats checked. True = Yes, one or both of them is the demon or red herring ; False = No, neither is the demon or red herring.'
+                description: 'YES if at least one seat reads as Demon (or Red Herring), else NO.'
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'A brief Storyteller explanation describing the mechanical and narrative factors that justified this result. Limit 2 sentences prefer 1.'
+                minLength: 1,
+                maxLength: 220,
+                description: 'Short mechanical + narrative justification.'
             }
         }
-    }
+    })
 };

--- a/src/prompts/fortuneTellersRedHerring.ts
+++ b/src/prompts/fortuneTellersRedHerring.ts
@@ -11,33 +11,18 @@ export const fortuneTellersRedHerring: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Choose which player receives the Fortune Teller's Red Herring reminder token, creating durable misdirection without nullifying the Fortune Teller. Per the FORTUNE TELLER ability this must be a GOOD character - e.g. TOWNSFOLK, OUTSIDER or the SPY.`,
+    goal: `Assign the Red Herring to a Good player to add misdirection without invalidating the Fortune Teller.`,
 
     additionalConsiderations: [
-        `LONGEVITY: Prefer a target unlikely to die early or hard-confirm themselves.`,
-        `PLAUSIBILITY: The target should plausibly be the Demon socially or mechanically.`,
-        `SUBTLETY: Avoid placements that collapse immediately under basic logic.`,
-        `SCRIPT SYNERGY: Ensure this misdirection complements other sources of uncertainty (drunk/poison/bluffs).`,
-        `CANNOT BE ASSIGNED to a MINION or DEMON`,
-        `BE WARY: Don't assign this to the RECLUSE as the RECLUSE's ability already causes it to misregister as a demon so putting a RED HERRING on a RECLUSE is a waste, generally.    `
+        `Target should live long enough to matter.`,
+        `Keep it plausible and subtle.`,
+        `Must be Good (not Minion/Demon).`,
+        `Avoid Recluse unless you have a strong reason.`
     ],
 
-    input: [
-        `Full grimoire`,
-        `Script context (roles in play, expected bluff structure)`,
-        `Optional player experience notes`
-    ],
+    input: [`Grimoire`, `Script context`, `Player experience notes (optional)`],
 
-    output: {
-        shown: 'object: { seat: number } (the seat with the Red Herring token)',
-        reasoning: {
-            type: 'string',
-            description:
-                'Brief ST philosophy explaining why this placement sustains Fortune Teller tension across the game. Limit to 2 sentences max, preferably 1.'
-        }
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'FortuneTellersRedHerringOutput',
         type: 'object',
@@ -46,21 +31,23 @@ export const fortuneTellersRedHerring: PromptSpec = {
         properties: {
             shown: {
                 type: 'object',
+                description: 'Chosen Red Herring seat.',
                 additionalProperties: false,
                 required: ['seat'],
                 properties: {
                     seat: {
-                        type: 'number',
+                        type: 'integer',
                         minimum: 1,
-                        maximum: playerCount,
+                        maximum: Math.max(1, playerCount),
                         description: 'The seat with the Red Herring token.'
                     }
                 }
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'Brief ST philosophy explaining why this placement sustains Fortune Teller tension across the game. Limit to 2 sentences max, preferably 1.'
+                minLength: 1,
+                maxLength: 220,
+                description: 'Why this placement sustains tension without breaking solvability.'
             }
         }
     })

--- a/src/prompts/goodClaimPlanner.ts
+++ b/src/prompts/goodClaimPlanner.ts
@@ -1,5 +1,6 @@
 // src/prompts/goodClaimPlanner.ts
 import { claimPlanner } from './claimPlanner';
+import { PromptSpec } from './prompt-types';
 
 /**
  * Wrapper for Townsfolk/Outsiders to plan:
@@ -15,9 +16,8 @@ export const goodClaimPlanner: PromptSpec = {
     tags: ['botc', 'player', 'good', 'claims', 'bluffs'],
     additionalConsiderations: [
         ...(claimPlanner.additionalConsiderations ?? []),
-        `TARGET MAGNETS: If your real role is a high-value Demon target (FT/Empath/Undertaker/Monk/Mayor), strongly consider delaying or bluffing low-impact early.`,
-        `FADE & BAIT: If your real role benefits from dying (Ravenkeeper) or is “spent” early (first-night roles), bluffing stronger can redirect kills or reduce nominations.`,
-        `TRUTH WINDOWS: Plan when you will “come clean” (e.g., after you’ve used your ability, after a key execution, or if you are nominated).`,
-        `TRUST TRADES: Your lane escalation should support building trust in stages without overexposing you.`
+        `Delay if you are a high-value Demon target.`,
+        `Plan when to reveal the truth.`,
+        `Use lane escalation to build trust.`
     ]
 };

--- a/src/prompts/impClaimPlanner.ts
+++ b/src/prompts/impClaimPlanner.ts
@@ -1,5 +1,6 @@
 // src/prompts/impClaimPlanner.ts
 import { claimPlanner } from './claimPlanner';
+import { PromptSpec } from './prompt-types';
 
 /**
  * Thin wrapper around claimPlanner with Imp-specific emphasis.
@@ -13,9 +14,8 @@ export const impClaimPlanner: PromptSpec = {
     tags: ['botc', 'player', 'imp', 'claims', 'bluffs'],
     additionalConsiderations: [
         ...(claimPlanner.additionalConsiderations ?? []),
-        `IMP SURVIVAL: Your claim should minimize getting executed while keeping you free to shape night outcomes.`,
-        `STAR-PASS COMPATIBILITY: Avoid claims that make a sudden death look impossible if you intend to star-pass later.`,
-        `SINK-KILL NARRATIVES: If you plan no-death nights, pick claims/bluffs (yours or teammates) that can “explain” them (Monk/Soldier framing).`,
-        `BEFORE BLUFFS ARE KNOWN: Use resilient claims that are unlikely to be out-of-play contradictions and that don’t require precise first-night info.`
+        `Avoid claims that prevent later star-pass stories.`,
+        `Plan a narrative for no-death nights.`,
+        `Keep early claims resilient to out-of-play risk.`
     ]
 };

--- a/src/prompts/impNightKill.ts
+++ b/src/prompts/impNightKill.ts
@@ -1,4 +1,6 @@
 // src/prompts/impNightKill.ts
+import { PromptSpec } from './prompt-types';
+
 export const impNightKill: PromptSpec = {
     id: 'imp-night-kill',
     version: '1.1',
@@ -7,35 +9,25 @@ export const impNightKill: PromptSpec = {
     perspective: 'player',
 
     instructions: [
-        `You are an AI player in Blood on the Clocktower whose role is the Imp.`,
-        `Each night, you must choose exactly one of four actions:`,
-        `• Kill a living player`,
-        `• Kill one of your Minions (a sacrifice)`,
-        `• Kill yourself to pass the Imp to a Minion (star-pass)`,
-        `• Target a dead player to cause no death (a sink-kill).`,
-        `Your decision should be made using partial information, public discussion, and your personality traits.`,
-        `You are not optimizing for perfect play; you are optimizing for winning while remaining believable.`
+        `You are the Imp in Blood on the Clocktower.`,
+        `Pick one action: kill a player, kill a minion, star-pass (self-kill), or sink-kill.`,
+        `Use partial info and follow PI wiki rules.`
     ],
 
     guidelines: [
-        `PRIMARY OBJECTIVE: Secure an Evil win by preventing Good from forming a confirmed world.`,
-        `SURVIVABILITY: Staying alive matters until it doesn’t; timing your death can be as important as avoiding it.`,
-        `INFORMATION PRESSURE: Shape what the town thinks should have happened, not just what did.`,
-        `SOCIAL CONSEQUENCES: Every night outcome (including no death) reshapes suspicion and trust.`,
-        `PERSONALITY CONSISTENCY: Your choice must align with how this Imp personality would plausibly act, even if another option is technically stronger.`
+        `Protect Evil win condition and keep Good uncertain.`,
+        `Use no-deaths or star-pass only when they fit the story.`,
+        `Match the risk level to your personality.`
     ],
 
-    footnote: `As the Imp, you control not only death, but expectation. Absence of a kill can speak louder than a corpse.`,
+    footnote: `Absence of a kill can be louder than a corpse.`,
 
-    goal: `Select a single night-kill action—player kill, minion sacrifice, star-pass, or sink-kill—that advances Evil while preserving plausible deniability.`,
+    goal: `Pick the night action that best advances Evil.`,
 
     additionalConsiderations: [
-        `PLAYER KILL: The default option. Best for removing confirmed or emerging information roles, strong social leaders, or players close to solving the game.`,
-        `MINION KILL (SACRIFICE): Useful to validate false Undertaker information, frame Good worlds, or remove a compromised Minion whose survival is more dangerous than their death.`,
-        `SELF-KILL (STAR-PASS): High-risk, high-impact. Consider when you are close to execution, your cover is broken, or passing to a better-positioned Minion resets suspicion.`,
-        `SINK-KILL (NO DEATH): Targeting a dead player to intentionally cause no death. Use to simulate protection (e.g. Monk bluff), failed attacks (e.g. Soldier bluff), or to inject confusion and delay.`,
-        `TIMING MATTERS: Early no-deaths can create uncertainty; repeated or poorly justified no-deaths can expose coordination.`,
-        `PATTERN AWARENESS: Alternating between kills and no-deaths may be safer than repeating either.`
+        `Kill info roles or social leaders.`,
+        `Use sink-kill to mimic protection or Soldier.`,
+        `Star-pass when your cover is broken.`
     ],
 
     personalityModulation: {
@@ -67,20 +59,43 @@ export const impNightKill: PromptSpec = {
     },
 
     input: [
-        `Your seat number`,
-        `List of living players with seat numbers`,
-        `List of dead players with seat numbers`,
-        `List of Minions and their seat numbers`,
-        `Public claims, statements, and voting behavior`,
-        `Rumors or protection / bluff narratives in circulation`,
-        `Current suspicion map (your internal beliefs)`,
-        `Night count and game phase`,
-        `Your personality profile`
+        `Your seat`,
+        `Living players list`,
+        `Dead players list`,
+        `Minion seats`,
+        `Public claims + votes`,
+        `Protection/bluff narratives`,
+        `Suspicion map`,
+        `Night count`,
+        `Personality profile`
     ],
 
-    output: {
-        action: "One of: 'kill_player', 'kill_minion', 'star_pass', or 'sink_kill'",
-        targetSeat: 'Seat number of the chosen target (use a dead player’s seat for sink_kill; use your own seat for star_pass)',
-        reasoning: 'In-character explanation of why this action was chosen, reflecting personality, partial information, and Evil strategy.'
-    }
+    output: ({ playerCount }: { playerCount: number }) => ({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        title: 'ImpNightKillOutput',
+        type: 'object',
+        additionalProperties: false,
+        required: ['action', 'targetSeat', 'reasoning'],
+        properties: {
+            action: {
+                type: 'string',
+                enum: ['kill_player', 'kill_minion', 'star_pass', 'sink_kill'],
+                minLength: 8,
+                maxLength: 11,
+                description: 'Chosen night action.'
+            },
+            targetSeat: {
+                type: 'integer',
+                minimum: 1,
+                maximum: Math.max(1, playerCount),
+                description: 'Target seat for the chosen action.'
+            },
+            reasoning: {
+                type: 'string',
+                minLength: 1,
+                maxLength: 260,
+                description: 'Why this action fits the current state.'
+            }
+        }
+    })
 };

--- a/src/prompts/librarianTokens.ts
+++ b/src/prompts/librarianTokens.ts
@@ -11,71 +11,73 @@ export const librarianTokens: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Choose what the Librarian learns: show an Outsider role and two candidate seats, one of which is correct (unless the Librarian is drunk/poisoned and you choose a legal falsehood).`,
+    goal: `Show an Outsider role and two seats, with one true unless drunk/poisoned.`,
 
     additionalConsiderations: [
-        `DEFAULT (SOBER/HEALTHY): Pick an in-play Outsider role and two candidates with exactly one correct.`,
-        `DRUNK OUTSIDER WEIGHTING: The Drunk Outsider often creates durable uncertainty without hard-confirmation.`,
-        `SPY REGISTRATION: Spy may register as Outsider. Use to widen plausible worlds, not to create obvious “ST trickery.”`,
-        `RECLUSE INTERACTION: Recluse misregistration should be believable and not immediately self-revealing.`,
-        `DRUNK/POISONED LIBRARIAN: You may show an Outsider not in play and/or make both candidates wrong. Keep it coherent with outsider-count discussions.`
+        `Sober/healthy: one seat must be correct.`,
+        `Drunk/poisoned: role and seats may be fully false.`,
+        `If no Outsider in play, show none.`
     ],
 
-    input: [
-        `Full grimoire`,
-        `Outsider count context (and which Outsiders exist on-script)`,
-        `Librarian sober/healthy state`
-    ],
+    input: [`Grimoire`, `Outsider count + script`, `Librarian sobriety/health`],
 
-    output: {
-        shown: `object: { role: string, seats: [number, number] } (what the Librarian is shown)`,
-        correctSeat: `number|null (which of shown.seats truly has that role; null if none/fully false). This number MUST be one of the two values in shown if defined.`,
-        reasoning: 'Brief ST philosophy explaining balance, longevity, and misregistration/sobriety choices.'
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'LibrarianTokensOutput',
         type: 'object',
         additionalProperties: false,
-        required: ['shown', 'reasoning'],
+        required: ['shown', 'correctSeat', 'reasoning'],
         properties: {
             shown: {
                 type: 'object',
+                description: 'Role and candidate seats shown.',
                 additionalProperties: false,
-                required: ['seats'],
+                required: ['role', 'seats'],
                 properties: {
                     role: {
-                        type: 'string',
-                        enum: outsiderRoles,
-                        description:
-                            'The role shown to the Librarian. Must be an outsider or null if there are no outsiders in play.'
+                        anyOf: [
+                            {
+                                type: 'string',
+                                enum: outsiderRoles,
+                                minLength: 3,
+                                maxLength: 20,
+                                description: 'Outsider role shown.'
+                            },
+                            { type: 'null', description: 'No Outsider shown.' }
+                        ],
+                        description: 'Outsider role or null if none in play.'
                     },
                     seats: {
                         type: 'array',
-                        minItems: 2,
+                        minItems: 0,
                         maxItems: 2,
+                        description: 'Two candidate seats, or empty if none.',
                         items: {
-                            type: 'number',
-                            minimum: 0,
-                            maximum: playerCount,
-                            description:
-                                'The two seats that are shown to the Librarian or 0 if there are no outsiders in play.'
+                            type: 'integer',
+                            minimum: 1,
+                            maximum: Math.max(1, playerCount),
+                            description: 'Candidate seat.'
                         }
                     }
                 }
             },
             correctSeat: {
-                type: 'number',
-                minimum: 1,
-                maximum: playerCount,
-                description:
-                    'The correct seat for the shown roles. Must be one of the two values in shown.seats if sober and healthy information. null if this is drunk or poisoned information or there are no outsiders in play.'
+                anyOf: [
+                    {
+                        type: 'integer',
+                        minimum: 1,
+                        maximum: Math.max(1, playerCount),
+                        description: 'True seat (must be one of shown.seats).'
+                    },
+                    { type: 'null', description: 'No true seat (drunk/poisoned or none in play).' }
+                ],
+                description: 'Which shown seat is true, or null.'
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'Brief ST philosophy for why this show is good for balance, drama, and plausibility. Max 2 sentences, prefer 1.'
+                minLength: 1,
+                maxLength: 240,
+                description: 'Why this result is legal and useful.'
             }
         }
     })

--- a/src/prompts/minionClaimPlanner.ts
+++ b/src/prompts/minionClaimPlanner.ts
@@ -1,5 +1,6 @@
 // src/prompts/minionClaimPlanner.ts
 import { claimPlanner } from './claimPlanner';
+import { PromptSpec } from './prompt-types';
 
 /**
  * Generic Minion wrapper. Use input “actual role” to specialize at runtime.
@@ -13,9 +14,8 @@ export const minionClaimPlanner: PromptSpec = {
     tags: ['botc', 'player', 'minion', 'claims', 'bluffs'],
     additionalConsiderations: [
         ...(claimPlanner.additionalConsiderations ?? []),
-        `MINION ROLE COVER: Choose claims that explain your behavior (e.g., why you talk to certain players, why you push certain executions).`,
-        `COORDINATION: Avoid colliding with Demon/other Minion claims. Prefer complementary lanes (different “tiers” of power).`,
-        `SACRIFICE OPTION: Sometimes you want to be executed or killed to validate a world; plan a lane that makes your death useful.`,
-        `PRE-BLUFF PHASE: Before official Demon bluffs are known, prioritize flexible claims that don’t require precise out-of-play certainty.`
+        `Choose claims that explain your social pushes.`,
+        `Avoid collisions with Demon/Minion claims.`,
+        `Keep a flexible pre-bluff lane.`
     ]
 };

--- a/src/prompts/monkProtect.ts
+++ b/src/prompts/monkProtect.ts
@@ -9,30 +9,25 @@ export const monkProtect: PromptSpec = {
     perspective: 'player',
 
     instructions: [
-        `You are an AI player in Blood on the Clocktower whose role is the Monk.`,
-        `Each night, you choose a seat number to protect from the Demon.`,
-        `You are not omniscient. You act on partial information filtered through your personality traits.`,
-        `Your play should be believable: you do not get perfect reads, and you sometimes protect the “wrong” person for coherent reasons.`
+        `You are the Monk in Blood on the Clocktower.`,
+        `Choose one seat to protect each night, using partial info and your personality.`,
+        `Follow Pandemonium Institute wiki rules for the Monk.`
     ],
 
     guidelines: [
-        `PRIMARY OBJECTIVE: Prevent high-value Good deaths while preserving your cover long enough to keep protecting.`,
-        `INFORMATION VALUE: Prefer protecting roles or players likely to generate reliable info next day (or who anchor town trust).`,
-        `RISK MANAGEMENT: If you are publicly suspected or likely to be targeted, consider self-protecting patterns indirectly (e.g., protecting your likely nomination shield or the player who can defend you).`,
-        `NARRATIVE CONTROL: A successful protection is loud. Protect in ways that don’t instantly hard-confirm you unless it is worth it.`,
-        `PERSONALITY CONSISTENCY: Your protect target and your willingness to “gamble” must match your personality traits.`
+        `Protect likely info sources or town anchors.`,
+        `Avoid creating a hard-confirm unless the trade is worth it.`,
+        `Match your risk tolerance to your personality.`
     ],
 
-    footnote: `Monk value is not only preventing deaths—it’s shaping the town’s belief about why a death did or didn’t happen.`,
+    footnote: `A save shapes both deaths and the town story.`,
 
-    goal: `Choose a seat number to protect tonight, maximizing Good survivability and information flow while staying believable.`,
+    goal: `Pick one protection target that preserves Good info and avoids exposing you.`,
 
     additionalConsiderations: [
-        `HIGH-VALUE TARGETS: Protect confirmed or likely info roles (Fortune Teller, Empath, Undertaker) if they are plausibly alive and not already protected by narrative.`,
-        `MAYOR DYNAMIC: If a Mayor is claimed, protection decisions interact with bounce expectations—avoid creating “too clean” confirmations.`,
-        `BAIT VS CORE: Sometimes protecting a socially influential player is better than protecting an info role no one trusts.`,
-        `TIMING: Early protection prioritizes unknown info roles; late protection prioritizes whoever is carrying the solve or likely final nomination.`,
-        `ANTI-TELEGRAPH: Don’t always protect the same archetype; patterns can get you executed.`
+        `Early: protect unknown info roles; late: protect the solve carrier.`,
+        `Avoid repetitive patterns that reveal you.`,
+        `Consider Mayor bounce expectations.`
     ],
 
     personalityModulation: {
@@ -64,38 +59,53 @@ export const monkProtect: PromptSpec = {
     },
 
     input: [
-        `Your seat number`,
-        `Living/dead list with seat numbers`,
-        `Public claims, rumors, and vote history`,
+        `Your seat`,
+        `Living/dead list`,
+        `Public claims + votes`,
         `Your suspicion map`,
-        `Any prior protection history (your own choices)`,
-        `Night count / game phase`,
-        `Your personality profile`
+        `Prior protection history`,
+        `Night count`,
+        `Personality profile`
     ],
 
-    output: {
-        shown: 'object: { seat: number } (the seat you choose to protect)',
-        todos: 'number[] (seat numbers you want to talk to tomorrow, in priority order)',
-        reasoning: 'In-character explanation tying protection choice to current information and personality.'
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'MonkProtectOutput',
         type: 'object',
         additionalProperties: false,
-        required: ['shown', 'reasoning'],
+        required: ['shown', 'todos', 'reasoning'],
         properties: {
-            choice: {
-                type: 'number',
-                minimum: 1,
-                maximum: playerCount,
-                description: 'The seat number of the person you want to protect from the demon this evening.'
+            shown: {
+                type: 'object',
+                description: 'Chosen protection target.',
+                additionalProperties: false,
+                required: ['seat'],
+                properties: {
+                    seat: {
+                        type: 'integer',
+                        minimum: 1,
+                        maximum: Math.max(1, playerCount),
+                        description: 'Seat to protect tonight.'
+                    }
+                }
+            },
+            todos: {
+                type: 'array',
+                description: 'Priority order of seats to talk to tomorrow.',
+                minItems: 0,
+                maxItems: Math.max(1, playerCount),
+                items: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: Math.max(1, playerCount),
+                    description: 'Seat number to prioritize.'
+                }
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'In-character explanation tying protection choice to current information and personality. 2 sentences max - prefer 1.'
+                minLength: 1,
+                maxLength: 240,
+                description: 'Why this protection fits the current state.'
             }
         }
     })

--- a/src/prompts/playerButlerChooseMaster.ts
+++ b/src/prompts/playerButlerChooseMaster.ts
@@ -10,46 +10,34 @@ export const playerButlerChooseMaster: PromptSpec = {
     perspective: 'player',
 
     instructions: [
-        'You are an AI player in a game of Blood on the Clocktower.',
-        'Your role is the Butler.',
-        'Each night, you must choose a living player to be your Master.',
-        'Tomorrow, you may only vote if your Master votes.',
-        'This choice is secret and should be made with awareness of both social and mechanical consequences.'
+        'You are the Butler in Blood on the Clocktower.',
+        'Each night choose a living Master; you can only vote if they vote.',
+        'Follow PI wiki rules and use partial info.'
     ],
 
     guidelines: [
-        'SELF-PRESERVATION: Choose a Master whose voting behavior will not unnecessarily restrict your ability to participate.',
-        'ALIGNMENT AWARENESS: If you believe you are Good, prefer a Master you trust to vote in critical moments.',
-        'MISDIRECTION: If you believe you are Evil or suspected, your Master choice can be used to confuse or frame.',
-        'FLEXIBILITY: Avoid choosing a Master who is likely to die, be executed, or abstain from voting.',
-        'CONSISTENCY: Your choice should make sense with your public behavior and claims if it is later revealed.'
+        'Pick a reliable voter who is likely to live.',
+        'If Good, choose someone you trust; if Evil, consider misdirection.',
+        'Keep the choice consistent with your public behavior.'
     ],
 
-    goal: 'Select a Master whose voting behavior best supports your strategy, survival, and alignment goals for the coming day.',
+    goal: 'Select a Master whose voting behavior supports your strategy.',
 
     additionalConsiderations: [
-        'SOCIAL SIGNALING: While the Master choice is private, its effects may become visible through your voting behavior.',
-        'ENDGAME IMPACT: In late-game scenarios, Master selection can directly decide whether you are able to vote at all.',
-        'EXECUTION RISK: If you expect to be executed or heavily scrutinized, choose a Master whose votes align with your desired narrative.',
-        'TRUST VS CONTROL: A highly active Master gives you more chances to vote; a passive Master gives you cover but less agency.',
-        'POISON / DRUNK STATUS: If you suspect you may be drunk or poisoned, your choice may be unreliable, but should still appear reasonable.'
+        'Late game: avoid Masters who abstain.',
+        'If you expect pressure, pick a Master whose votes help your story.'
     ],
 
     input: [
-        'Your seat number',
-        'List of living players with seat numbers',
-        'Public claims and voting behavior so far',
-        'Your current suspicion map',
-        'Current day and night number',
-        'Your personality profile (if applicable)'
+        'Your seat',
+        'Living players list',
+        'Public votes/claims',
+        'Suspicion map',
+        'Current day/night',
+        'Personality profile'
     ],
 
-    output: {
-        chosenSeat: 'Seat number of the player you choose as your Master',
-        reasoning: 'A brief in-character explanation of why this player was chosen as your Master.'
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'ButlerChooseMaster',
         type: 'object',
@@ -57,16 +45,16 @@ export const playerButlerChooseMaster: PromptSpec = {
         required: ['chosenSeat', 'reasoning'],
         properties: {
             chosenSeat: {
-                type: 'number',
+                type: 'integer',
                 minimum: 1,
-                maximum: playerCount,
-                description: 'Seat number of the player you choose as your Master. This must not be yourself.'
+                maximum: Math.max(1, playerCount),
+                description: 'Seat of the chosen Master (not yourself).'
             },
             reasoning: {
                 type: 'string',
                 minLength: 1,
-                description:
-                    'A brief in-character explanation of why this player was chosen as your Master. Limit 2 sentences prefer 1.'
+                maxLength: 200,
+                description: 'Why this Master choice fits your plan.'
             }
         }
     })

--- a/src/prompts/poisonerNightAction.ts
+++ b/src/prompts/poisonerNightAction.ts
@@ -13,30 +13,25 @@ export const poisonerNightAction: PromptSpec = {
     perspective: 'player',
 
     instructions: [
-        `You are an AI player in Blood on the Clocktower whose role is the Poisoner.`,
-        `Each night, choose exactly one seat number to poison.`,
-        `The target may be living or dead if doing so meaningfully distorts Good information or protects the Demon.`,
-        `You are not omniscient. You act on partial information filtered through your personality traits.`
+        `You are the Poisoner in Blood on the Clocktower.`,
+        `Pick one seat to poison each night, using partial info and your personality.`,
+        `Follow Pandemonium Institute wiki rules.`
     ],
 
     guidelines: [
-        `TEAM PRIORITY: Protect the Demon and advance Evil’s win condition.`,
-        `MISINFORMATION VALUE: Prefer poisons that distort reliable information or prolong uncertainty.`,
-        `PLAUSIBLE DENIABILITY: Avoid poison patterns that make your identity trivial to deduce over repeated nights.`,
-        `PERSONALITY CONSISTENCY: Your risk tolerance and target logic must match your personality profile.`,
-        `INFORMATION HORIZON: Prefer poisons with downstream impact, not just tonight’s effect.`
+        `Protect the Demon and prolong uncertainty.`,
+        `Avoid obvious poison patterns.`,
+        `Match risk to personality.`
     ],
 
-    footnote: `Unlike the Storyteller, you cannot justify outcomes retroactively. Each poison is a public commitment to a theory of the game.`,
+    footnote: `Each poison is a public commitment to a story.`,
 
-    goal: `Choose a seat number to poison tonight that best advances Evil given public claims, rumors, suspicions, and your personality.`,
+    goal: `Choose a poison target that best advances Evil.`,
 
     additionalConsiderations: [
-        `NEIGHBOR STRATEGIES: Poisoning your own neighbor may distort an Empath read; poisoning the Demon’s neighbor may protect the Demon.`,
-        `SINK POISON: Poisoning a dead player can still matter for registration or ongoing interactions (e.g. Recluse affecting Fortune Teller).`,
-        `INFO ROLE TARGETING: Empath, Fortune Teller, Undertaker, Chef, etc. are often high-value poison targets.`,
-        `TEAMWORK: When feasible, coordinate with your Demon to enable kills on protected or high-risk targets (Mayor/Soldier/Ravenkeeper).`,
-        `TARGETING EVIL: There are very few situations where targeting a fellow evil players makes sense. This should be done very sparingly. (Focus on townsfolk with strong abilities and outsiders)`
+        `Poison info roles or key social leaders.`,
+        `Consider Empath-neighbor distortion.`,
+        `Only poison Evil in rare, high-value cases.`
     ],
     personalityModulation: {
         trustModel: {
@@ -68,23 +63,17 @@ export const poisonerNightAction: PromptSpec = {
     // Keep your existing personality modulation format if you already have it in code elsewhere;
     // we leave it optional here since you may inject it at runtime.
     input: [
-        `Your seat number`,
-        `Demon seat number`,
-        `Minion info (all Minions and seats)`,
-        `Bare-bones grimoire snapshot (living/dead, seating order)`,
-        `Public claims and statements so far`,
-        `Your internal suspicion map`,
-        `Poisoning history (prior targets by night)`,
-        `Your personality profile`
+        `Your seat`,
+        `Demon seat`,
+        `Minion seats`,
+        `Living/dead list`,
+        `Public claims`,
+        `Suspicion map`,
+        `Poison history`,
+        `Personality profile`
     ],
 
-    output: {
-        shown: 'object: { seat: number } (the seat you choose to poison)',
-        reasoning:
-            'In-character explanation of why this seat was chosen, reflecting personality and partial information.'
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'PoisonerNightActionOutput',
         type: 'object',
@@ -93,21 +82,23 @@ export const poisonerNightAction: PromptSpec = {
         properties: {
             shown: {
                 type: 'object',
+                description: 'Chosen poison target.',
                 additionalProperties: false,
                 required: ['seat'],
                 properties: {
                     seat: {
-                        type: 'number',
+                        type: 'integer',
                         minimum: 1,
-                        maximum: playerCount,
-                        description: 'The seat of the person that will be poisoned this evening.'
+                        maximum: Math.max(1, playerCount),
+                        description: 'Seat to poison tonight.'
                     }
                 }
             },
             reasoning: {
                 type: 'string',
-                description:
-                    'In-character explanation of why this seat was chosen, reflecting personality and partial information. Max 2 sentences - prefer 1.'
+                minLength: 1,
+                maxLength: 220,
+                description: 'Why this target advances Evil.'
             }
         }
     })

--- a/src/prompts/prompt-types.ts
+++ b/src/prompts/prompt-types.ts
@@ -39,7 +39,7 @@ export type JsonSchema = {
  * Intentional design goals:
  * - Stable top-level keys across prompts
  * - Consistent IO: always use `input` and `output` (but we still allow legacy `inputs`)
- * - Optional `schema` to validate model output
+ * - Output schema factory for model output
  */
 export type PromptSpec = {
     // ---------- metadata ----------
@@ -70,18 +70,10 @@ export type PromptSpec = {
     inputs?: string[];
 
     /**
-     * Output fields as a schema-ish description map (human-readable).
-     * This is what your existing prompt files most naturally store.
+     * Machine-checkable JSON schema for model output.
+     * Pass in playerCount so seat numbers can be bounded.
      */
-    output:
-        | Record<string, string | { type: any; description: any }>
-        | { fields: Record<string, string>; notes?: string | string[] };
-
-    /**
-     * Machine-checkable schema for model output. Strongly recommended.
-     * This should match the real JSON you expect from the model.
-     */
-    schema?: JsonSchema | ((variable: any) => JsonSchema);
+    output: ({ playerCount }: { playerCount: number }) => JsonSchema;
 };
 
 const voiceStyles = z.enum(['quiet', 'reserved', 'conversational', 'assertive', 'dominant']);

--- a/src/prompts/ravenkeeperShowing.ts
+++ b/src/prompts/ravenkeeperShowing.ts
@@ -11,35 +11,35 @@ export const ravenkeeperShowing: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Determine which role to show the Ravenkeeper about their chosen target after the Ravenkeeper dies at night.`,
+    goal: `Show the Ravenkeeper a role for their chosen target after a night death.`,
 
     additionalConsiderations: [
-        `TARGET INTEGRITY: Honor the Ravenkeeper’s chosen target exactly; do not “redirect” their choice.`,
-        `SOBRIETY AT DEATH: Evaluate the Ravenkeeper’s sobriety/health at the moment of death for whether their info can be false.`,
-        `MISREGISTRATION: Use Recluse/Spy registration options deliberately. If Recluse is drunk/poisoned, do not misregister them.`,
-        `ENDGAME POWER: Ravenkeeper info can hard-lock worlds late. Prefer roles that create debate unless the game state needs a hard reveal.`
+        `Honor the chosen target.`,
+        `If drunk/poisoned, lie but stay coherent.`,
+        `Apply Recluse/Spy misregistration only when legal.`
     ],
 
-    input: [`Full grimoire`, `Ravenkeeper target seat number`, `Ravenkeeper sober/healthy state at time of death`],
+    input: [`Grimoire`, `Ravenkeeper target seat`, `Ravenkeeper sobriety at death`],
 
-    output: {
-        role: 'string (role shown to the Ravenkeeper for the chosen target)',
-        reasoning: {
-            type: 'string',
-            description:
-                'Brief ST philosophy explaining balance, plausibility, and any misregistration/sobriety choices. 2 sentence limit, prefer 1 sentence.'
-        }
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'RavenkeeperShowingOutput',
         type: 'object',
         additionalProperties: false,
         required: ['role', 'reasoning'],
         properties: {
-            role: { type: 'string' },
-            reasoning: { type: 'string' }
+            role: {
+                type: 'string',
+                minLength: 2,
+                maxLength: 30,
+                description: 'Role shown for the target.'
+            },
+            reasoning: {
+                type: 'string',
+                minLength: 1,
+                maxLength: 220,
+                description: 'Why this role is legal and helpful.'
+            }
         }
     })
 };

--- a/src/prompts/travelerAlignment.ts
+++ b/src/prompts/travelerAlignment.ts
@@ -9,61 +9,58 @@ export const travelerAlignment: PromptSpec = {
     perspective: 'storyteller',
 
     instructions: [
-        'You are the Storyteller for a game of Blood on the Clocktower.',
-        'A Traveler has just entered the game after setup.',
-        'You must decide whether the Traveler is aligned with GOOD or EVIL.',
-        'This decision is made with full knowledge of the current game state and should be intentional, not random.',
-        'Your role is to preserve game balance, narrative tension, and player agency.'
+        'You are the Storyteller for Blood on the Clocktower.',
+        'Assign a Traveler alignment using PI wiki guidance and the current game state.',
+        'Balance tension without hard-deciding the game.'
     ],
 
     guidelines: [
-        'BALANCE FIRST: Use Traveler alignment to stabilize a game that is tilting too far toward one team.',
-        'INFORMATION ECONOMY: Consider how much reliable information currently exists and which team is benefiting from it.',
-        'PLAYER EXPERIENCE: Travelers are highly visible; their alignment should create interesting pressure, not dead air.',
-        'NARRATIVE CONSISTENCY: The chosen alignment should make sense given the public story of the game so far.',
-        'NON-DETERMINISM: Avoid choices that immediately decide the game unless the game is already effectively decided.'
+        'Use alignment to stabilize a tilted game.',
+        'Keep it narratively coherent and interesting.',
+        'Avoid choices that hard-end the game.'
     ],
 
-    goal: 'Choose an alignment (GOOD or EVIL) for the incoming Traveler that best supports a fair, dramatic, and strategically interesting game.',
+    goal: 'Choose GOOD or EVIL for the Traveler to improve balance and tension.',
 
     additionalConsiderations: [
-        'GOOD-LEANING CHOICE: Favor GOOD if Evil has strong momentum, multiple surviving Minions, or highly constrained Good worlds.',
-        'EVIL-LEANING CHOICE: Favor EVIL if Good has strong confirmation chains, multiple solved worlds, or near-certain executions.',
-        'TRAVELER ROLE IMPACT: Some Traveler abilities are inherently disruptive or swingy; weigh how dangerous they are on each team.',
-        'TIMING MATTERS: Early-game Travelers can absorb chaos; late-game Travelers can be decisive. Adjust alignment accordingly.',
-        'SOCIAL DYNAMICS: Consider whether the table will naturally trust or distrust this Traveler regardless of alignment.',
-        'INTERACTION WITH EXISTING EFFECTS: Account for poison, drunkenness, execution patterns, and any active misinformation.'
+        'Lean Good if Evil has momentum; lean Evil if Good is confirmed.',
+        'Consider Traveler role swinginess and timing.',
+        'Account for current misinformation effects.'
     ],
 
     input: [
-        'Current full grimoire (roles, alignments, alive/dead status, reminder tokens)',
-        'Current day and night number',
-        'Public claims and major narrative threads',
-        'Traveler seat number',
-        'Traveler role',
-        'Known or suspected game imbalance indicators'
+        'Grimoire + reminders',
+        'Current day/night',
+        'Public context',
+        'Traveler seat + role',
+        'Imbalance indicators'
     ],
 
-    output: {
-        alignment: "One of: 'good' | 'evil'",
-        travelerID: 'the seatID for the traveler',
-        reasoning:
-            'A concise Storyteller explanation describing how this alignment choice improves balance, tension, or narrative clarity.'
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'TravelerAlignmentDecision',
         type: 'object',
         additionalProperties: false,
-        required: ['alignment', 'reasoning'],
+        required: ['alignment', 'travelerID', 'reasoning'],
         properties: {
             alignment: {
                 type: 'string',
-                enum: ['good', 'evil']
+                enum: ['good', 'evil'],
+                minLength: 4,
+                maxLength: 4,
+                description: 'Chosen alignment for the Traveler.'
+            },
+            travelerID: {
+                type: 'integer',
+                minimum: 1,
+                maximum: Math.max(1, playerCount),
+                description: 'Traveler seat number.'
             },
             reasoning: {
-                type: 'string'
+                type: 'string',
+                minLength: 1,
+                maxLength: 240,
+                description: 'Why this alignment improves balance and tension.'
             }
         }
     })

--- a/src/prompts/undertakerShowing.ts
+++ b/src/prompts/undertakerShowing.ts
@@ -11,35 +11,35 @@ export const undertakerShowing: PromptSpec = {
 
     ...genericStorytellerCore,
 
-    goal: `Determine which role to show the Undertaker for the most recently executed player.`,
+    goal: `Show the Undertaker a role for the most recently executed player.`,
 
     additionalConsiderations: [
-        `EXECUTED PLAYER: Use the most recently executed player (the one executed during the day that just ended).`,
-        `SOBRIETY & HEALTH: If Undertaker is drunk/poisoned, the shown role may be incorrect. Keep it coherent, not random.`,
-        `MISREGISTRATION: Apply Recluse/Spy registrations intentionally. If Recluse is drunk/poisoned, do not misregister them.`,
-        `COLLISION VALUE: When lying (legally), pick a role that meaningfully collides with current claims rather than a random role.`
+        `Use the last executed player.`,
+        `If drunk/poisoned, lie but stay coherent.`,
+        `Apply Recluse/Spy misregistration only when legal.`
     ],
 
-    input: [`Recently executed player's seat number`, `Full grimoire`, `Undertaker sober/healthy state`],
+    input: [`Executed player seat`, `Grimoire`, `Undertaker sobriety/health`],
 
-    output: {
-        role: 'string (role shown to the Undertaker for the executed player)',
-        reasoning: {
-            type: 'string',
-            description:
-                'Brief ST philosophy explaining balance, plausibility, and any misregistration/sobriety choices. 2 sentence limit, prefer 1 sentence.'
-        }
-    },
-
-    schema: ({ playerCount }: { playerCount: number }) => ({
+    output: ({ playerCount }: { playerCount: number }) => ({
         $schema: 'http://json-schema.org/draft-07/schema#',
         title: 'UndertakerShowingOutput',
         type: 'object',
         additionalProperties: false,
         required: ['role', 'reasoning'],
         properties: {
-            role: { type: 'string' },
-            reasoning: { type: 'string' }
+            role: {
+                type: 'string',
+                minLength: 2,
+                maxLength: 30,
+                description: 'Role shown to the Undertaker.'
+            },
+            reasoning: {
+                type: 'string',
+                minLength: 1,
+                maxLength: 220,
+                description: 'Why this role is legal and useful.'
+            }
         }
     })
 };

--- a/src/server/createJSONschemas.ts
+++ b/src/server/createJSONschemas.ts
@@ -15,8 +15,7 @@ import { demonBluffs } from '../prompts/demonBluffs';
 import { monkProtect } from '../prompts/monkProtect';
 
 function processThis(spec: PromptSpec) {
-    const wwSchema = spec.schema;
-    const schema = typeof wwSchema === 'function' ? wwSchema({ playerCount: 15 }) : wwSchema;
+    const schema = spec.output({ playerCount: 15 });
     if (!schema) return;
     const zodObject = jsonSchemaToZod(schema);
 


### PR DESCRIPTION
### Motivation

- Reduce prompt token usage by condensing Storyteller/player instructions and guidance while keeping intent intact. 
- Align prompt behavior with the Pandemonium Institute (PI) wiki rules for Blood on the Clocktower so outputs are legally defensible and narratively useful.
- Make model outputs machine-checkable and size-bounded by converting prompt `output` metadata into a schema factory that accepts `playerCount` to bound seat numbers.

### Description

- Reworked `PromptSpec` so `output` is now a schema factory: `output: ({ playerCount }: { playerCount: number }) => JsonSchema` and removed the legacy freeform `output/schema` mix. (`src/prompts/prompt-types.ts`).
- Updated prompt rendering and schema generation to call the new factories, e.g. `createPrompt` now calls `output({ playerCount })` and server schema tooling uses `spec.output({ playerCount: 15 })`. (`src/prompts/createPrompt.ts`, `src/server/createJSONschemas.ts`).
- Compactified Storyteller core guidance and many player prompts to reduce tokens while keeping rules-oriented guidance (references to PI wiki added). (`src/prompts/_genericStorytellerCore.ts` and many `src/prompts/*.ts`).
- Replaced previous informal `output` maps with concrete JSON Schema factories across prompts, adding descriptions and constraints (types, `minLength`/`maxLength`, `minItems`/`maxItems`, seat bounds derived from `playerCount`, enums where appropriate). Examples: `monkProtect`, `chefNumber`, `washerwomanTokens`, `fortuneTellerNightAction`, `claimPlanner`, `spyIntel`, `worldBuilder`, and many others under `src/prompts/`.
- Normalized integer vs number usage for seats and added `anyOf`/`null` patterns where a `null` value is meaningful (e.g., no-true-seat when drunk/poisoned).
- Tidied up related prompt wrappers (good/minion/imp claim planners) to reuse the compact core and to import `PromptSpec` types consistently.
- Applied Prettier formatting across the updated files.

### Testing

- Ran formatting: `npm run format -- --write "src/**/*.ts" "src/**/*.tsx"` to apply Prettier; this completed successfully (files were formatted). 
- Note: an initial `npm run format` (without file globs) printed Prettier usage info; the explicit `--write` invocation fixed that and succeeded. No other automated test suites (`npm run test`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969082b5a04832a81c048f1014aaf7a)